### PR TITLE
Fix floating point precision in calculator

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -47,11 +47,13 @@
 
 <body>
 	<audio src="media/startup.mp3" id="startup-music"></audio>
-	<div id="loadback" style="background-color:#000;width:100%;height:100%;z-index:105;position:absolute;transition:200ms;">
+	<div id="loadback"
+		style="background-color:#000;width:100%;height:100%;z-index:105;position:absolute;transition:200ms;">
 		<style>
 			#loadback.hide {
 				opacity: 0;
 			}
+
 			loading>svg>circle:last-child {
 				stroke: #fff;
 				fill: none;
@@ -61,31 +63,180 @@
 				transform-origin: 50% 50%;
 				transition: all .2s ease-in-out 0s;
 			}
+
 			loading>svg {
 				background-color: #00000000;
 				border-radius: 50%;
 			}
+
 			@keyframes spin-infinite {
 				0% {
 					stroke-dasharray: .01px, 43.97px;
 					transform: rotate(0deg)
 				}
+
 				50% {
 					stroke-dasharray: 21.99px, 21.99px;
 					transform: rotate(450deg)
 				}
+
 				to {
 					stroke-dasharray: .01px, 43.97px;
 					transform: rotate(3turn)
 				}
 			}
 		</style>
-		<svg id="loadbacksvg" viewBox="21,18,320,315" style="transition: 1s;opacity: 0;position: absolute;left: calc(50% - 125px);top:20%;" width="250" height="250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="5.81006 5.77778"/></filter><filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="5.77778 5.77778"/></filter><filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="7.36593 7.36776"/></filter><filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.521569" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="6 6"/></filter><clipPath id="clip4"><rect x="468" y="169" width="362" height="356"/></clipPath><clipPath id="clip5"><rect x="-6.53632" y="-6.5" width="101.061" height="108"/></clipPath><clipPath id="clip6"><rect x="0" y="0" width="90" height="95"/></clipPath><linearGradient x1="525.053" y1="357.279" x2="645.947" y2="458.721" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill7"><stop offset="0" stop-color="#775CFE"/><stop offset="0.18" stop-color="#775CFE"/><stop offset="0.83" stop-color="#2473DC"/><stop offset="1" stop-color="#2473DC"/></linearGradient><clipPath id="clip8"><rect x="-6.5" y="-6.5" width="125" height="115"/></clipPath><clipPath id="clip9"><rect x="0" y="0" width="112" height="105"/></clipPath><linearGradient x1="511.623" y1="213.086" x2="642.377" y2="368.914" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill10"><stop offset="0" stop-color="#C45DD5"/><stop offset="0.18" stop-color="#C45DD5"/><stop offset="0.69" stop-color="#A266E4"/><stop offset="1" stop-color="#A266E4"/></linearGradient><clipPath id="clip11"><rect x="-7.53336" y="-7.53522" width="128.067" height="124.08"/></clipPath><clipPath id="clip12"><rect x="0" y="0" width="113" height="107"/></clipPath><linearGradient x1="617.245" y1="376.897" x2="771.755" y2="466.103" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill13"><stop offset="0" stop-color="#61A2F9"/><stop offset="0.18" stop-color="#61A2F9"/><stop offset="0.91" stop-color="#3159D7"/><stop offset="1" stop-color="#3159D7"/></linearGradient><clipPath id="clip14"><rect x="-6.5" y="-6.5" width="130" height="137"/></clipPath><clipPath id="clip15"><rect x="0" y="0" width="118" height="124"/></clipPath><linearGradient x1="643.458" y1="199.26" x2="791.542" y2="375.74" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill16"><stop offset="0" stop-color="#8A66FE"/><stop offset="0.19" stop-color="#8A66FE"/><stop offset="1" stop-color="#2473DC"/></linearGradient></defs><g clip-path="url(#clip4)" transform="translate(-468 -169)"><g clip-path="url(#clip5)" filter="url(#fx0)" transform="matrix(1.98889 0 0 2 499 310)"><g clip-path="url(#clip6)" transform="translate(2.84217e-14 0)"><path d="M71.8132 77.0858 26.981 77.0858C22.0288 77.0858 18.0143 73.1038 18.0143 68.1917L18.0143 19.9983C27.6747 18.8595 31.5867 17.632 40.5532 18.2527 49.5197 18.8734 62.1334 21.5426 71.8132 23.7225L71.8132 77.0858Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M639 467 549.834 467C539.984 467 532 459.036 532 449.212L532 352.825C551.213 350.547 558.994 348.093 576.827 349.334 594.661 350.575 619.748 355.914 639 360.273L639 467Z" fill="url(#fill7)" fill-rule="evenodd"/><g clip-path="url(#clip8)" filter="url(#fx1)" transform="matrix(2 0 0 2 468 189)"><g clip-path="url(#clip9)"><path d="M17.9142 86.9142 17.9142 29.4144C17.9142 23.063 23.0408 17.9142 29.3649 17.9142L87.6795 17.9142C91.3242 35.2574 94.0833 41.1006 93.9062 52.6006 93.729 64.1006 89.0466 75.4763 86.6168 86.9142 70.0706 84.6993 65.4194 82.6717 53.5245 82.4844 41.5652 82.296 29.7843 85.4376 17.9142 86.9142Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M501 360 501 245C501 232.298 511.253 222 523.901 222L640.531 222C647.82 256.686 653.338 268.373 652.984 291.373 652.63 314.373 643.265 337.124 638.405 360 605.313 355.57 596.01 351.515 572.221 351.14 548.302 350.764 524.74 357.047 501 360Z" fill="url(#fill10)" fill-rule="evenodd"/><g clip-path="url(#clip11)" filter="url(#fx2)" transform="matrix(1.99115 0 0 1.99065 579 312)"><g clip-path="url(#clip12)"><path d="M90.4862 22.6918 90.4862 74.1822C90.4862 79.8698 85.8764 84.4806 80.1899 84.4806L28.7099 84.4806C25.6989 69.2628 22.7773 68.0805 22.6877 54.0451 22.5938 39.3223 26.7026 33.1429 28.7099 22.6918L90.4862 22.6918Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M762 360 762 462.5C762 473.822 752.821 483 741.499 483L638.994 483C632.999 452.707 627.181 450.353 627.003 422.414 626.816 393.105 634.997 380.805 638.994 360L762 360Z" fill="url(#fill13)" fill-rule="evenodd"/><g clip-path="url(#clip14)" filter="url(#fx3)" transform="matrix(2 0 0 2 594 169)"><g clip-path="url(#clip15)"><path d="M18.7308 18.4142 86.1097 18.4142C93.5523 18.4142 99.5858 24.4663 99.5858 31.932L99.5858 99.5195C79.053 102.327 71.9105 106.654 58.5202 105.134L18.7308 99.5195C21.1161 80.9213 23.4541 75.8406 23.5014 62.3231 23.5527 47.6868 20.321 33.0505 18.7308 18.4142Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M639 203 769.833 203C784.285 203 796 214.752 796 229.248L796 360.486C756.13 365.937 742.262 374.34 716.261 371.389L639 360.486C643.632 324.373 648.171 314.508 648.263 288.26 648.363 259.84 642.088 231.42 639 203Z" fill="url(#fill16)" fill-rule="evenodd"/></g></svg>
+		<svg id="loadbacksvg" viewBox="21,18,320,315"
+			style="transition: 1s;opacity: 0;position: absolute;left: calc(50% - 125px);top:20%;" width="250"
+			height="250" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+			overflow="hidden">
+			<defs>
+				<filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+					primitiveUnits="userSpaceOnUse">
+					<feComponentTransfer color-interpolation-filters="sRGB">
+						<feFuncR type="discrete" tableValues="0 0" />
+						<feFuncG type="discrete" tableValues="0 0" />
+						<feFuncB type="discrete" tableValues="0 0" />
+						<feFuncA type="linear" slope="0.4" intercept="0" />
+					</feComponentTransfer>
+					<feGaussianBlur stdDeviation="5.81006 5.77778" />
+				</filter>
+				<filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+					primitiveUnits="userSpaceOnUse">
+					<feComponentTransfer color-interpolation-filters="sRGB">
+						<feFuncR type="discrete" tableValues="0 0" />
+						<feFuncG type="discrete" tableValues="0 0" />
+						<feFuncB type="discrete" tableValues="0 0" />
+						<feFuncA type="linear" slope="0.4" intercept="0" />
+					</feComponentTransfer>
+					<feGaussianBlur stdDeviation="5.77778 5.77778" />
+				</filter>
+				<filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+					primitiveUnits="userSpaceOnUse">
+					<feComponentTransfer color-interpolation-filters="sRGB">
+						<feFuncR type="discrete" tableValues="0 0" />
+						<feFuncG type="discrete" tableValues="0 0" />
+						<feFuncB type="discrete" tableValues="0 0" />
+						<feFuncA type="linear" slope="0.4" intercept="0" />
+					</feComponentTransfer>
+					<feGaussianBlur stdDeviation="7.36593 7.36776" />
+				</filter>
+				<filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+					primitiveUnits="userSpaceOnUse">
+					<feComponentTransfer color-interpolation-filters="sRGB">
+						<feFuncR type="discrete" tableValues="0 0" />
+						<feFuncG type="discrete" tableValues="0 0" />
+						<feFuncB type="discrete" tableValues="0 0" />
+						<feFuncA type="linear" slope="0.521569" intercept="0" />
+					</feComponentTransfer>
+					<feGaussianBlur stdDeviation="6 6" />
+				</filter>
+				<clipPath id="clip4">
+					<rect x="468" y="169" width="362" height="356" />
+				</clipPath>
+				<clipPath id="clip5">
+					<rect x="-6.53632" y="-6.5" width="101.061" height="108" />
+				</clipPath>
+				<clipPath id="clip6">
+					<rect x="0" y="0" width="90" height="95" />
+				</clipPath>
+				<linearGradient x1="525.053" y1="357.279" x2="645.947" y2="458.721" gradientUnits="userSpaceOnUse"
+					spreadMethod="reflect" id="fill7">
+					<stop offset="0" stop-color="#775CFE" />
+					<stop offset="0.18" stop-color="#775CFE" />
+					<stop offset="0.83" stop-color="#2473DC" />
+					<stop offset="1" stop-color="#2473DC" />
+				</linearGradient>
+				<clipPath id="clip8">
+					<rect x="-6.5" y="-6.5" width="125" height="115" />
+				</clipPath>
+				<clipPath id="clip9">
+					<rect x="0" y="0" width="112" height="105" />
+				</clipPath>
+				<linearGradient x1="511.623" y1="213.086" x2="642.377" y2="368.914" gradientUnits="userSpaceOnUse"
+					spreadMethod="reflect" id="fill10">
+					<stop offset="0" stop-color="#C45DD5" />
+					<stop offset="0.18" stop-color="#C45DD5" />
+					<stop offset="0.69" stop-color="#A266E4" />
+					<stop offset="1" stop-color="#A266E4" />
+				</linearGradient>
+				<clipPath id="clip11">
+					<rect x="-7.53336" y="-7.53522" width="128.067" height="124.08" />
+				</clipPath>
+				<clipPath id="clip12">
+					<rect x="0" y="0" width="113" height="107" />
+				</clipPath>
+				<linearGradient x1="617.245" y1="376.897" x2="771.755" y2="466.103" gradientUnits="userSpaceOnUse"
+					spreadMethod="reflect" id="fill13">
+					<stop offset="0" stop-color="#61A2F9" />
+					<stop offset="0.18" stop-color="#61A2F9" />
+					<stop offset="0.91" stop-color="#3159D7" />
+					<stop offset="1" stop-color="#3159D7" />
+				</linearGradient>
+				<clipPath id="clip14">
+					<rect x="-6.5" y="-6.5" width="130" height="137" />
+				</clipPath>
+				<clipPath id="clip15">
+					<rect x="0" y="0" width="118" height="124" />
+				</clipPath>
+				<linearGradient x1="643.458" y1="199.26" x2="791.542" y2="375.74" gradientUnits="userSpaceOnUse"
+					spreadMethod="reflect" id="fill16">
+					<stop offset="0" stop-color="#8A66FE" />
+					<stop offset="0.19" stop-color="#8A66FE" />
+					<stop offset="1" stop-color="#2473DC" />
+				</linearGradient>
+			</defs>
+			<g clip-path="url(#clip4)" transform="translate(-468 -169)">
+				<g clip-path="url(#clip5)" filter="url(#fx0)" transform="matrix(1.98889 0 0 2 499 310)">
+					<g clip-path="url(#clip6)" transform="translate(2.84217e-14 0)">
+						<path
+							d="M71.8132 77.0858 26.981 77.0858C22.0288 77.0858 18.0143 73.1038 18.0143 68.1917L18.0143 19.9983C27.6747 18.8595 31.5867 17.632 40.5532 18.2527 49.5197 18.8734 62.1334 21.5426 71.8132 23.7225L71.8132 77.0858Z"
+							fill="#FF0000" fill-rule="evenodd" />
+					</g>
+				</g>
+				<path
+					d="M639 467 549.834 467C539.984 467 532 459.036 532 449.212L532 352.825C551.213 350.547 558.994 348.093 576.827 349.334 594.661 350.575 619.748 355.914 639 360.273L639 467Z"
+					fill="url(#fill7)" fill-rule="evenodd" />
+				<g clip-path="url(#clip8)" filter="url(#fx1)" transform="matrix(2 0 0 2 468 189)">
+					<g clip-path="url(#clip9)">
+						<path
+							d="M17.9142 86.9142 17.9142 29.4144C17.9142 23.063 23.0408 17.9142 29.3649 17.9142L87.6795 17.9142C91.3242 35.2574 94.0833 41.1006 93.9062 52.6006 93.729 64.1006 89.0466 75.4763 86.6168 86.9142 70.0706 84.6993 65.4194 82.6717 53.5245 82.4844 41.5652 82.296 29.7843 85.4376 17.9142 86.9142Z"
+							fill="#FF0000" fill-rule="evenodd" />
+					</g>
+				</g>
+				<path
+					d="M501 360 501 245C501 232.298 511.253 222 523.901 222L640.531 222C647.82 256.686 653.338 268.373 652.984 291.373 652.63 314.373 643.265 337.124 638.405 360 605.313 355.57 596.01 351.515 572.221 351.14 548.302 350.764 524.74 357.047 501 360Z"
+					fill="url(#fill10)" fill-rule="evenodd" />
+				<g clip-path="url(#clip11)" filter="url(#fx2)" transform="matrix(1.99115 0 0 1.99065 579 312)">
+					<g clip-path="url(#clip12)">
+						<path
+							d="M90.4862 22.6918 90.4862 74.1822C90.4862 79.8698 85.8764 84.4806 80.1899 84.4806L28.7099 84.4806C25.6989 69.2628 22.7773 68.0805 22.6877 54.0451 22.5938 39.3223 26.7026 33.1429 28.7099 22.6918L90.4862 22.6918Z"
+							fill="#FF0000" fill-rule="evenodd" />
+					</g>
+				</g>
+				<path
+					d="M762 360 762 462.5C762 473.822 752.821 483 741.499 483L638.994 483C632.999 452.707 627.181 450.353 627.003 422.414 626.816 393.105 634.997 380.805 638.994 360L762 360Z"
+					fill="url(#fill13)" fill-rule="evenodd" />
+				<g clip-path="url(#clip14)" filter="url(#fx3)" transform="matrix(2 0 0 2 594 169)">
+					<g clip-path="url(#clip15)">
+						<path
+							d="M18.7308 18.4142 86.1097 18.4142C93.5523 18.4142 99.5858 24.4663 99.5858 31.932L99.5858 99.5195C79.053 102.327 71.9105 106.654 58.5202 105.134L18.7308 99.5195C21.1161 80.9213 23.4541 75.8406 23.5014 62.3231 23.5527 47.6868 20.321 33.0505 18.7308 18.4142Z"
+							fill="#FF0000" fill-rule="evenodd" />
+					</g>
+				</g>
+				<path
+					d="M639 203 769.833 203C784.285 203 796 214.752 796 229.248L796 360.486C756.13 365.937 742.262 374.34 716.261 371.389L639 360.486C643.632 324.373 648.171 314.508 648.263 288.26 648.363 259.84 642.088 231.42 639 203Z"
+					fill="url(#fill16)" fill-rule="evenodd" />
+			</g>
+		</svg>
 		<loading id="loadbackloading" style="transition:1s;opacity:0;">
-			<svg style="position:absolute;left:calc(50% - 25px);top:72%;" width="50px" height="50px" viewBox="0 0 16 16">
+			<svg style="position:absolute;left:calc(50% - 25px);top:72%;" width="50px" height="50px"
+				viewBox="0 0 16 16">
 				<circle cx="8px" cy="8px" r="7px"></circle>
 			</svg>
-			<p id="loadbackupdate" style="position:absolute;top:calc(72% + 55px);left:0;width:100%;text-align:center;color:#fff;font-size: 25px;display:none;">正在更新</p>
+			<p id="loadbackupdate"
+				style="position:absolute;top:calc(72% + 55px);left:0;width:100%;text-align:center;color:#fff;font-size: 25px;display:none;">
+				正在更新</p>
 		</loading>
 		<script>
 			setTimeout(() => {
@@ -128,8 +279,10 @@
 			登录
 		</div>
 		<a class="power" onclick="$(this).addClass('show')">
-			<i class="bi bi-power" onclick="setTimeout(() => {window.location='shutdown.html';}, 200);" win12_title="关机"></i>
-			<i class="bi bi-arrow-counterclockwise" onclick="setTimeout(() => {window.location='reload.html';}, 200);" win12_title="重启"></i>
+			<i class="bi bi-power" onclick="setTimeout(() => {window.location='shutdown.html';}, 200);"
+				win12_title="关机"></i>
+			<i class="bi bi-arrow-counterclockwise" onclick="setTimeout(() => {window.location='reload.html';}, 200);"
+				win12_title="重启"></i>
 		</a>
 	</div>
 	<!-- <img src="https://bing.com/th?id=OHR.Trossachs_ZH-CN9299955040_UHD.jpg&qlt=100" alt=""> -->
@@ -138,7 +291,36 @@
 		<!-- 开始菜单 -->
 		<div id="s-m-l">
 			<div id="s-m-user">
-				<svg viewBox="0,0,257,344" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="user-clip0"><rect x="382" y="195" width="257" height="344" /></clipPath><linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill1"><stop offset="0" stop-color="#A964C8" /><stop offset="0.35" stop-color="#A964C8" /><stop offset="0.87" stop-color="#2D8AD5" /><stop offset="1" stop-color="#2D8AD5" /></linearGradient><linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill2"><stop offset="0" stop-color="#A964C8" /><stop offset="0.35" stop-color="#A964C8" /><stop offset="0.87" stop-color="#2D8AD5" /><stop offset="1" stop-color="#2D8AD5" /></linearGradient></defs><g clip-path="url(#user-clip0)" transform="translate(-382 -195)"><path d="M637.755 433.872C642.215 515.221 579.577 537.983 508.011 537.983 436.444 537.983 376.676 507.833 383.513 437.11 383.109 425.234 389.59 414.133 398.634 409.891 413.82 402.768 444.753 402.936 507.484 402.997 570.214 403.058 609.164 402.279 621.521 407.947 633.878 413.614 638.011 424.609 637.755 433.872Z" fill="url(#user-fill1)" fill-rule="evenodd" /><path d="M422 285C422 235.847 461.623 196 510.5 196 559.377 196 599 235.847 599 285 599 334.153 559.377 374 510.5 374 461.623 374 422 334.153 422 285Z" fill="url(#user-fill2)" fill-rule="evenodd" /></g></svg>
+				<svg viewBox="0,0,257,344" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+					overflow="hidden">
+					<defs>
+						<clipPath id="user-clip0">
+							<rect x="382" y="195" width="257" height="344" />
+						</clipPath>
+						<linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill1">
+							<stop offset="0" stop-color="#A964C8" />
+							<stop offset="0.35" stop-color="#A964C8" />
+							<stop offset="0.87" stop-color="#2D8AD5" />
+							<stop offset="1" stop-color="#2D8AD5" />
+						</linearGradient>
+						<linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill2">
+							<stop offset="0" stop-color="#A964C8" />
+							<stop offset="0.35" stop-color="#A964C8" />
+							<stop offset="0.87" stop-color="#2D8AD5" />
+							<stop offset="1" stop-color="#2D8AD5" />
+						</linearGradient>
+					</defs>
+					<g clip-path="url(#user-clip0)" transform="translate(-382 -195)">
+						<path
+							d="M637.755 433.872C642.215 515.221 579.577 537.983 508.011 537.983 436.444 537.983 376.676 507.833 383.513 437.11 383.109 425.234 389.59 414.133 398.634 409.891 413.82 402.768 444.753 402.936 507.484 402.997 570.214 403.058 609.164 402.279 621.521 407.947 633.878 413.614 638.011 424.609 637.755 433.872Z"
+							fill="url(#user-fill1)" fill-rule="evenodd" />
+						<path
+							d="M422 285C422 235.847 461.623 196 510.5 196 559.377 196 599 235.847 599 285 599 334.153 559.377 374 510.5 374 461.623 374 422 334.153 422 285Z"
+							fill="url(#user-fill2)" fill-rule="evenodd" />
+					</g>
+				</svg>
 			</div>
 			<p style="width: 100%;text-align: center;margin: -50px 0 20px 0;font-size: 30px;">Administartor</p>
 			<input type="text" class="input" win12_title="搜索" placeholder="在这里输入你要搜索的内容" onfocus="hide_startmenu();
@@ -353,11 +535,36 @@
 					</div>
 				</div>
 				<div class="apps">
-					<a class="a tj-obj act"><img src="icon/files/ppt.png"><div><p>科学地使用瓶盖.pptx</p><p>5 分钟前</p></div></a>
-					<a class="a tj-obj act"><img src="icon/files/img.png"><div><p>可口可乐瓶盖.jpg</p><p>7 分钟前</p></div></a>
-					<a class="a tj-obj act"><img src="icon/files/img.png"><div><p>瓶盖构造图.jpg</p><p>16 分钟前</p></div></a>
-					<a class="a tj-obj act"><img src="icon/files/word.png"><div><p>瓶盖的构造及作用.docx</p><p>24 分钟前</p></div></a>
-					<a class="a tj-obj act"><img src="icon/files/excel.png"><div><p>可口可乐瓶盖厚度.xlsx</p><p>35 分钟前</p></div></a>
+					<a class="a tj-obj act"><img src="icon/files/ppt.png">
+						<div>
+							<p>科学地使用瓶盖.pptx</p>
+							<p>5 分钟前</p>
+						</div>
+					</a>
+					<a class="a tj-obj act"><img src="icon/files/img.png">
+						<div>
+							<p>可口可乐瓶盖.jpg</p>
+							<p>7 分钟前</p>
+						</div>
+					</a>
+					<a class="a tj-obj act"><img src="icon/files/img.png">
+						<div>
+							<p>瓶盖构造图.jpg</p>
+							<p>16 分钟前</p>
+						</div>
+					</a>
+					<a class="a tj-obj act"><img src="icon/files/word.png">
+						<div>
+							<p>瓶盖的构造及作用.docx</p>
+							<p>24 分钟前</p>
+						</div>
+					</a>
+					<a class="a tj-obj act"><img src="icon/files/excel.png">
+						<div>
+							<p>可口可乐瓶盖厚度.xlsx</p>
+							<p>35 分钟前</p>
+						</div>
+					</a>
 				</div>
 			</div>
 		</div>
@@ -507,12 +714,23 @@
 					<div class="monitor">
 						<div class="wg monitor">
 							<div class="titbar">
-								<a win12_title="更多" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" class="a more notip" onclick="$('.wg.monitor>.titbar>.menu').toggleClass('show')"><i class="bi bi-three-dots"></i></a>
+								<a win12_title="更多" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)"
+									class="a more notip" onclick="$('.wg.monitor>.titbar>.menu').toggleClass('show')"><i
+										class="bi bi-three-dots"></i></a>
 								<div class="menu">
-									<a class="a chose" win12_title="切换监视器类型" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" onclick="shownotice('widgets.monitor')"><i class="bi bi-arrow-left-right"></i></a>
-									<a class="a move" win12_title="移动 (不可用)" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)"><i class="bi bi-arrows-move"></i></a>
-									<a class="a addtotb" win12_title="添加到任务栏" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" onclick="widgets.widgets.addToToolbar('monitor')"><i class="bi bi-menu-app"></i></a>
-									<a class="a delete" win12_title="删除" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" onclick="$('.wg.monitor>.titbar>.menu').removeClass('show');widgets.widgets.remove('monitor')"><i class="bi bi-trash"></i></a>
+									<a class="a chose" win12_title="切换监视器类型" onmouseenter="showdescp(event)"
+										onmouseleave="hidedescp(event)" onclick="shownotice('widgets.monitor')"><i
+											class="bi bi-arrow-left-right"></i></a>
+									<a class="a move" win12_title="移动 (不可用)" onmouseenter="showdescp(event)"
+										onmouseleave="hidedescp(event)"><i class="bi bi-arrows-move"></i></a>
+									<a class="a addtotb" win12_title="添加到任务栏" onmouseenter="showdescp(event)"
+										onmouseleave="hidedescp(event)"
+										onclick="widgets.widgets.addToToolbar('monitor')"><i
+											class="bi bi-menu-app"></i></a>
+									<a class="a delete" win12_title="删除" onmouseenter="showdescp(event)"
+										onmouseleave="hidedescp(event)"
+										onclick="$('.wg.monitor>.titbar>.menu').removeClass('show');widgets.widgets.remove('monitor')"><i
+											class="bi bi-trash"></i></a>
 								</div>
 							</div>
 							<div class="content">
@@ -545,9 +763,12 @@
 				<p style="color: #7f7f7f;margin-right: 5px;margin-top: 2px;">注意: 新闻内容均不属实 </p>
 			</div>
 			<div class="content">
-				<div class="card" style="grid-column: 1/6;grid-row: 1/3;color: #fff;background: var(--bgul);background-position:-0px -278px;background-size: 100%;">
-					<p class="tit" style="font-size: 20px;margin: 90px 0 0 30px;text-shadow: 0 0 8px #000;">Windows12 v6.0 发布</p>
-					<a class="a" style="margin: 5px 0 0 50px;font-size: 17px;color: #9dd0fb;text-shadow: 0 0 3px #000;" onclick="hide_widgets();
+				<div class="card"
+					style="grid-column: 1/6;grid-row: 1/3;color: #fff;background: var(--bgul);background-position:-0px -278px;background-size: 100%;">
+					<p class="tit" style="font-size: 20px;margin: 90px 0 0 30px;text-shadow: 0 0 8px #000;">Windows12
+						v6.0 发布</p>
+					<a class="a" style="margin: 5px 0 0 50px;font-size: 17px;color: #9dd0fb;text-shadow: 0 0 3px #000;"
+						onclick="hide_widgets();
 					openapp('about');if($('.window.about').hasClass('min'))minwin('about');
 					$('#win-about>.about').removeClass('show');$('#win-about>.update').addClass('show');
 					$('#win-about>.update>div>details:first-child').attr('open','open')">详细信息 ></a>
@@ -574,15 +795,18 @@
 					<p class="tit" style="margin: 100px 0 0px 10px;color: #fff;">微软发布 Windows Subsystem for MacOS</p>
 					<a class="a" style="margin: 0 0 0 170px;font-size: 17px;color: #9dd0fb;">详细信息 ></a>
 				</div>
-				<div class="card" style="grid-column: 3/6;grid-row: 5/7;background:linear-gradient(#00000000 0 30%,var(--bg) 70%),url(img/mc.jpg) bottom;background-size: cover;">
+				<div class="card"
+					style="grid-column: 3/6;grid-row: 5/7;background:linear-gradient(#00000000 0 30%,var(--bg) 70%),url(img/mc.jpg) bottom;background-size: cover;">
 					<p class="tit" style="margin: 100px 0 -20px 10px;">今日凌晨,Minecraft把代理权交给中国航天员谭景元,网易败下阵来了?</p>
 					<a class="a" style="margin: 0 0 0 170px;font-size: 17px;">详细信息 ></a>
 				</div>
-				<div class="card" style="grid-column: 1/4;grid-row: 3/5;background:linear-gradient(#00000000 0 30%,var(--bg) 80%),url(img/yq.jpg) center;background-size: cover;">
+				<div class="card"
+					style="grid-column: 1/4;grid-row: 3/5;background:linear-gradient(#00000000 0 30%,var(--bg) 80%),url(img/yq.jpg) center;background-size: cover;">
 					<p class="tit" style="margin: 120px 0 -20px 10px;">中国航天员谭景元昨天下午成功登月</p>
 					<a class="a" style="margin: 0 0 0 150px;font-size: 17px;">详细信息 ></a>
 				</div>
-				<div class="card" style="grid-column: 3/6;grid-row: 9/11;background:linear-gradient(#00000000 0 30%,var(--bg) 80%),url(img/office.png) center;background-size: cover;">
+				<div class="card"
+					style="grid-column: 3/6;grid-row: 9/11;background:linear-gradient(#00000000 0 30%,var(--bg) 80%),url(img/office.png) center;background-size: cover;">
 					<p class="tit" style="margin: 100px 0 0 10px;">微软发布声控Office套件，用户可以用嗓子完成文件编辑</p>
 					<a class="a" style="margin: 0 0 0 160px;font-size: 17px;">详细信息 ></a>
 				</div>
@@ -593,7 +817,8 @@
 				</div>
 				<div class="card" style="grid-column: 1/3;grid-row: 9/11;background:#171b22;">
 					<p class="tit" style="font-size: 19px;margin: 50px 0 0 10px;color: #fff;">想给新闻增加更多奇思妙想?
-						<br />快在github上来提交吧</p>
+						<br />快在github上来提交吧
+					</p>
 					<a class="a" win12_title="https://github.com/tjy-gitnub/win12/issues"
 						style="margin: 10px 0 0 70px;font-size: 17px;color: #9dd0fb" onclick="
 					window.open('https://github.com/tjy-gitnub/win12/issues','_blank');">提交issues ></a>
@@ -618,8 +843,10 @@
 			<p style="margin-top: 20px;">注意:目前后端发生了一点小问题，大概率不能使用，若能使用当然就运气好了。</p>
 		</div>
 		<div class="inputbox disable">
-			<input type="text" class="input" onkeydown="if(event.keyCode==13){copilot.send($(this).val());$(this).val('');this.blur()}">
-			<a class="a send btn" onclick="copilot.send($('#copilot>.inputbox>.input').val());$('#copilot>.inputbox>.input').val('');">发送</a>
+			<input type="text" class="input"
+				onkeydown="if(event.keyCode==13){copilot.send($(this).val());$(this).val('');this.blur()}">
+			<a class="a send btn"
+				onclick="copilot.send($('#copilot>.inputbox>.input').val());$('#copilot>.inputbox>.input').val('');">发送</a>
 		</div>
 	</div>
 	<div id="control">
@@ -667,7 +894,8 @@
 					<div class="icon">
 						<icon class="s-icon"></icon>
 					</div>
-					<div class="range-container" onmousedown="dragBrightness(event)" ontouchstart="dragBrightness(event)">
+					<div class="range-container" onmousedown="dragBrightness(event)"
+						ontouchstart="dragBrightness(event)">
 						<div class="after"></div>
 						<div class="slider-btn"></div>
 					</div>
@@ -683,7 +911,13 @@
 		</div>
 		<div class="cont">
 			<div class="head">
-				<p>一</p><p>二</p><p>三</p><p>四</p><p>五</p><p>六</p><p>日</p>
+				<p>一</p>
+				<p>二</p>
+				<p>三</p>
+				<p>四</p>
+				<p>五</p>
+				<p>六</p>
+				<p>日</p>
 			</div>
 			<div class="body">
 			</div>
@@ -753,8 +987,55 @@
 				}, 0);
 				$('#search-input').focus();
 			}">
-				<svg class="out" width="26" height="26" viewBox="0,0,228,229" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="clip-search-out-0"><rect x="548" y="268" width="228" height="229"/></clipPath><linearGradient x1="738.799" y1="300.076" x2="608.064" y2="486.786" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-search-out-1"><stop offset="0" stop-color="#A6A6A6"/><stop offset="0.18" stop-color="#A6A6A6"/><stop offset="0.91" stop-color="#595959"/><stop offset="1" stop-color="#595959"/></linearGradient></defs><g clip-path="url(#clip-search-out-0)" transform="translate(-548 -268)"><path d="M640 268.696C690.41 268.696 731.276 309.574 731.276 360 731.276 378.91 725.529 396.477 715.687 411.049L713.816 413.318 771.4 470.903C777.068 476.571 777.068 485.761 771.4 491.429 765.732 497.097 756.542 497.097 750.874 491.429L693.292 433.847 691.033 435.711C676.465 445.556 658.904 451.305 640 451.304 589.59 451.305 548.724 410.426 548.724 360 548.724 309.574 589.59 268.696 640 268.696Z" fill="url(#fill-search-out-1)" fill-rule="evenodd"/></g></svg>
-				<svg class="in" width="20" height="20" viewBox="0,0,134,134" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="clip-search-in-0"><rect x="573" y="293" width="134" height="134"/></clipPath><linearGradient x1="611.068" y1="280.509" x2="668.932" y2="439.491" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-search-in-1"><stop offset="0" stop-color="#82CDF6"/><stop offset="0.18" stop-color="#82CDF6"/><stop offset="0.91" stop-color="#4297D6"/><stop offset="1" stop-color="#4297D6"/></linearGradient><image width="132" height="132" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAMAAABmmnOVAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFZUExURQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKhZnwEAAABzdFJOUwABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJv0gLZAAAACXBIWXMAAA7DAAAOwwHHb6hkAAARAklEQVR4XsWb91caWRTH2TQbFjoMvUlHmoKggihiw94Su8ZojInZ/P8/7Pfe9wZI1wjZ7zm7x8AM8zm3vpl5V/OHGvSMlde3tk5OLm9vzw8P19ZWpuMurfzyL2gotvjm5u7D+5vr63dXV28vLy+ELi/fnm6VRwflYd3TQKh2/unu9j0uf3lxfnZ6cnJ8fHR0yDo6Oj4+OT0735vy98vDu6CRscYtCG6uAXB2enx0+PrgYH9/b3d3h7S7u7u3v3/w+vDo+OTNbLgrBnkVnD+/B8G7txdnJ8e4/t7u9tbmxsb6+lpDaG1tfX1jc2sbLAdvjjYn3S/lqZ3Si+zV548f3l8TwdGbg72drY31xurK8tLiYr2+sLBQq+F/9fri0vLKagMo27v7rw83o8/l6Z2QPn94//HDzbvL85Oj1/u725vrjZWl+kJtvlqdrZTL5RlWuVyZna3O1xbqS8uraxtbO3sHy4kR+RNPVV/pw/3H25ury7Pjw4Pd7Y211eXFhflqpTwzVSoWJwuFPDSRzxcKk8ViaWqmXKnO1epLK431rZ397Uyf/JmnqDd3+vnj7fXVxSmMsLO5trpUr83NlqdLxUJ+YjyXzaTT6RQpnc5kstnceL4wCZJKdX5hcaWxsbW7En0yRnDj308fbhhhb3ujsVyvVSszU8XCRC6bTo0lE/FYLEqK4L9YPJ5IjqXSGZBMFqfLs/MLSytrmzszLvljfybT7O393ft3cAQhrC4tzFVmSpP58Wx6DJePhEOjwUAg4Gfhj2BwNBSORGOJZCqTnSiAo1qDOTY3Mnr5g38g7y15QiCsA6Fani7mxzOpJAHg+n6f1+N2u11C+Mvj9fr8gWAoHI0nxjK5icnSzOx8fbmxsW6XP/lYaafv7u9urs5P3jBCrVqempzIppPxKABwfbfL6XDYFUWxSSmK3e5wOl0ery8wGorEEqnMeL44XZlbWG6sJ/+oijrXvnz6cP327OhgB44AQqkwnhlLgMDv87iduLzNarGYTSaTUZXJZLZYrDbF7gCIPxiKxJOp7MTkVGWuvrJWMMsffoTGkBTv313ADFtry3DEFCHEo6Ggz+NyEgAubzTo9TqdbkSVTqc3GIxGM0CIA/YIRxPAKE7Pzi+uVr3ypx+qZ8V7uEKYYWVxvjI1SQiR0YDP7XIoVhgAALqR4eHhoaGhQVVDQ8PDQNEbjCYzOJxumIMwcvniTLW2tBr+R/78g9Rb+XL/4fry9BBmWKrNTk9OMILfCwKbRQLg4toBqL+pgQGtVguWYQIBhwIOXzAUTaZzhVJ5rr4aeyUv8AAN1b58uiVX7G6uLs6VS/ksI3icdiZgAC0u3tfX+436+vrAIkDAYbEqhBGOJTPjk9OzC8vJBxcu48q/YDg/PthZX1mozsATyWgoACsQAmxABAP9AOiBXrWLPgAJcwgMs9Xu9PhHI/FUNj9VmV9KD8mL/EavDv/9+P7q/Ohge225NjtVyKbi4aDP7VAsJoMeRlAJcNGXpBdS/I+XjAKLMAfcYrTY7C5vAD7JTBRn5urFF/Iyv9QQ7EAM+1uNpflyaYLMAE8Qgo4IyAkwAF/8udAzSP4pYAQIccAcRrPN4YJP4qlcYbpaTz3AI701ssMZMSzOzRTH04kImcFmNurhB9UGhEDXpMu3qwUCDsYYGtYZTAgNjz8UG8sWpmYX4r9d7Dwrf4EdzpAWq/Xq9GQuFQsFYAYrmYERWkYQl/2nTeITJgGHxIBT2Bhu3yhcki9Var/N1CLyAr7Y2wQDwiEZHZVmGB7UEgKM0CSQl5ZnauQ/mYNIyBw9PYQhjeENhhPpCVAE5Bk/0dj9PfICviCGfDYZCXpdMAM8oR0gBOEGuoi8pDxPSn5IYgxwkDXgEzaGJ4DAGC+Wq055/A/lPLn/oDJM5zPEgIikaGAzfIfwnV3lxyRhDXilp1cYg1ziDzHF5C9au3bt8931xfHBVoPskEFIepw2M0cDmwEIRMAI8pSfqokBp/T2IUBH9CarHRQxokj2yMO+1/SXjzeXJwfbjUVmCAc8DuGK/iYCXf/3BCw6UGCoxjBa7C7fKFFUfhoW8btP79+evtlZW5qbRkxGmMEwgohkBnIEIzyMQaV4Jij6mhSwxURpWpEHfaPeWwTE2eHu+vL8zCTFpMdhgx2QmL0UkJJBHvwgqRSMgfhkCooL5MjUjyvnLAUEknOlVi7mmAG+oHBQzfBYBjVOVWMgS1oUUz90SPD2483bk4Ot1YXZ0ngqirz4hoF+Tx77YDEEU7xAsrItKDrDiUyhaJLHtKl34/726gwBgaCcSMdGvU4bxcPTGL6iYFsM60xW1ItIMjcZ+7585/69u0al3FiamylkEiGfSzFTPDyRQaiNYnAYmerwBKNj46XvSlYfMgPZuYWAoKAMuBVLB+ygiikoMMgWepPN6R2NpScK38Zm6TMyg5whAgJBadShPnSGoWmLlz3I1BGDWXEhLLIFj/xWSn+KMnW8t7E8j2odD/kQEPph1IcOMbR5pG9ApEgADkl/fS+Sp6h8vb26UIEzwn43B0QHGVQKqhdIVIQFOST/VVQMH36kErG+hMwYE84YGRpAx+oYQ4uCw8JsY4cke+WXpBwMcfp6axVRqTpjSEtB2TmGJoUIC4sdGZIaby/eVx9vLlCvUSLGxygzzAY1IDrHwBRIEeqpCAur0xuKZ9LyKyj4+cPVKaUnSkR81OuwGHWUnR1mEBRNhyjuQGQsZ5BfaTTzSA1ExGK1BEP4XQplRl/vKwqITjKAghyCmgWHGCk245nm/enIOWoEUqNWJkN4HFSm0L1VQ8ijOiJhCsoQik2YohmaY/fvL4/3N5AaZAhEpW6ozRnyoM6o5RDEJpvCIr9poGsc7jQWKDVGvXaLYViUiM4ztGXIkN7EUSE7+sDnW7TwzeW5adSIgIvSUxqi4wyAoAwhUyBNOSqyopfGPt1cHO2u1SvFLLonUmNEpGcXGFRTUFSIBImmxLKieifCciafjgbdlBrUPNkQ/H1H1W4KrhVJN39+AG9QWJbGk2Gfy4buKVOjGxCtqIAp0MeCsRB9alG9QWHJ+SlqBIUln9ZhkSkoQQYGdVhY+CNjA/gweXd99oa9kYpSoWrPT3FahyVNgbKJDuINJSgoFm+vODemyBtOtM/BATU/xUmdljAFZ6lZ8QRjFBS7qFQo2bPFLLxBRYLWU2wIcU7HxRDoY/3kD5c/gkrx4uL6gitVIR1DbpjbioQ8qdPiBGEIyg9fKPJMY6AE3VqZR6USJbvb3pCm4FJhMGNZEe/V+KiLU4LmEmEfrahQqbpqCEgERa8s3dFhTYpDgsol9Q2sZrrtDYhMIeuVzemLGDUzVCWaIYG+gZLdxfwUEv6Q/SOkaNbQQUWViFDz0lEDZUN0G0Itmp5Rj2ZDxCVW2WE/Vwm1b3QX4hmKJlcKVG6PZgdxublMjYM6KKoEQkIs6+QJ3ZBMUix4TYor4NMcoF4iOYq5BK1w0UHRvLodEgLipSxXAb/miFoo18ugx25uQcjDuyPYmdsHp4c/oDnnoo0WGsP9BnUvlKruJigJphA9jGpmUPOWFvt1ytC/DPGc0wM56hvVvOXFBCCiAkJmqDy4W2pBoJsHNWe4/0OtwtLOj1UV34r/PQjkKCD8mjfcQ8WKRoXodly2Q2BJ4dXs/f8Qbs0mQci13f8E4dKsCoiJFO6E/ycIh2blB5b4m4GJZY1DU+LsIAg00b8NoR2iFDVrEpeoE4CgOiEh/mqxAoRO42EIWTH/DwiHV6vRidVdIcMLq79UttUGRr3D4evRvHhzvE8NjLsoQ1AX7ToEL63Eot+DazXobhitHOsJauW8qPkrEOpKl3a6zIqVVS4ZwqJGrKy6nh4cEuKeWHHRDpMorTHlnSjfkos1pji6S1IhhnRmxT2MD0y02pY3YLTQlYWiqw4RELTaRq3i53drR1wyUShQrXjJj6DoblTwaltmqHiyXDze40cksaDnb9wPQyIuxc2P08gfjYqHRblEiB8favu7DQEGNSSMNpfYPdpP6SEik26Im0HBX3ZBCDeCUG+I5Z7NWfVpkbgPHOjrbs0kCPXRgMWhbgELt56boVzRiw5+iCm/7bgkhHxIom70GdykoKBHqV6HlZ4pd+0pJosZeDGB+y+l+XJ0svmoBv6g904iSeW3nZZqCHjDbG+973DTWrdMjZTvBNWi2R0K9gbXbHrnQQ8xpbb58R2S1Oe08suOrtUrIKiVitaX7e/AYgfsjxS9/+rmQ35hB1mpKDfa958NLre/7uCn/AKi4xQCgosEwtL61YvqhPqEHU2MS4Vqik5TqIYQzevrXd0jK/QuEPWKn6eqpbsLFBSVFJZcJKzf7IxM7a7Rk5KEeLzd9oy9sxD4vVZ+Kjr5qaq+nU0OTZjCbtGLl2CdhxDOkIXK6vhuq390p4HSTS+gnPTepSsJIhnIGUgNhZZUX6t3hlopmQIFS9YKppDfd0DsCxGVlBqmH8w8uDYaC5ViDglCLwTFu/KOVixiYGdQVOLOq61YtpTZWJ6bztOeHt5GAodQsegYhWQQUYmFxLdRKdSz3qijdicjARdtGxgU+yc6RcEMzag0WpSfDKD411fmxdai9t0snaEQdqCoFNsnbD8d10ryJqsUmmnLIZ2haDKIXU5m5ecTMP2FVRmbtI+Ddzipew/lEX+opi9e9VJmGK2GX+xZNleXySG8owXVG3lKwflkijaGfg4Ic/temu/kXREOQYZgzUth0QGPtOIBiUEMPw8IoTA7RO4wEhRP9UiLgRKDtnp9Xyq/1j8xckg2GQ6gh/CmM0qRp1C0xwOqFAXlb3/pVZL2pWYSCE6iEB5BpjLGH4AIBBkPSE6zTfdMfvUL9aXr1al8Oh7yu5hisB+Z2qJ4BAYfLlzBuaklX9h+lRgtvSjVZ0sTKaSIoNBSvSCXPNYYzMA9i32BeNCbbaYH2IE0mFqolMaRIj63Xe5Obe5WJgx52O/EBBQNHJKUF2SH327kV9UXr1WKoAghLuSe6b5e2kBPxniIU/iQVjTwXmXkJtZSD/KF0MtwrSwpaNc0kkQa43kTQx75QzFBO4Pcta2MPNAXUoH5cjGHuPB7aJyAJxqI4kEYKkHTDBSSejD8rj58J2cetkjHwwGeL2lOFIgIbXpFSJ6iWkACcDBQcdDyTn6r+Q/mnPXJcnGCRky8LruVN/SL2Qo53UEc7SAtCQQQwArsCWEGwy/7xc/UE5jmYZtRBIZNjDbwlInAUDkgeXFI/Fs1Ao/ciFEXi23kESH5lYxTU4XcWCwcYGPwvA1bQ8wcCZAWC18dYhsgFEBAQz+EoChPmK8eDBQnx9MJGINGbsw0/EQDYDx9JTlI4uJ0eVyfCcgGYgyLrGDX/XyS4iEyxUoTWRgj6CWf8AyWmEMTHOoYlir6AAQqgk5vNFsV0w/X1Y/RS2emQMbgaTRYw6jX0TxcayCOBtCa4qE4Gs9rzqIptuFOzFRrPel8NkXTibCGYiVztCYD+4lFlRwPpEHFEZ3BaIYjrE/0REv9zqQckvS6aT7QzBOKACESGIWFP7Q0KTnM44k0J6k4rCOPmEj8rZ4pmVwLQ53V1OvUaU0S/lJHRk08MaoMPbTXPVTPDd4kDc6Ggn6v2yXmZmlu1WgADMlA86owAI2sKg6nYhh4XKN4oHotgVQqGYsQBw/wgsRmpRleksViseLyit3hdDnNQw9u2Y9Xv8kdGksQR4AmqV0uJ7NAdrvdQVPMbo9iHOxkJPxYPQb3aCwejfBQud/n83o9JK/X6/M6umqCb/VyyGj3eD3BwGgYFcTrcDjMuoE/aw8azX8p1DsCWPfRswAAAABJRU5ErkJggg==" preserveAspectRatio="none" id="img2"></image><clipPath id="clip-search-in-3"><rect x="574" y="294" width="132" height="132"/></clipPath></defs><g clip-path="url(#clip-search-in-0)" transform="translate(-573 -293)"><path d="M574 360C574 323.549 603.549 294 640 294 676.451 294 706 323.549 706 360 706 396.451 676.451 426 640 426 603.549 426 574 396.451 574 360Z" fill="url(#fill-search-in-1)" fill-rule="evenodd"/><g clip-path="url(#clip-search-in-3)"><use width="100%" height="100%" xlink:href="#img2" transform="translate(574 294)"></use></g></g></svg>
+				<svg class="out" width="26" height="26" viewBox="0,0,228,229" xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+					<defs>
+						<clipPath id="clip-search-out-0">
+							<rect x="548" y="268" width="228" height="229" />
+						</clipPath>
+						<linearGradient x1="738.799" y1="300.076" x2="608.064" y2="486.786"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-search-out-1">
+							<stop offset="0" stop-color="#A6A6A6" />
+							<stop offset="0.18" stop-color="#A6A6A6" />
+							<stop offset="0.91" stop-color="#595959" />
+							<stop offset="1" stop-color="#595959" />
+						</linearGradient>
+					</defs>
+					<g clip-path="url(#clip-search-out-0)" transform="translate(-548 -268)">
+						<path
+							d="M640 268.696C690.41 268.696 731.276 309.574 731.276 360 731.276 378.91 725.529 396.477 715.687 411.049L713.816 413.318 771.4 470.903C777.068 476.571 777.068 485.761 771.4 491.429 765.732 497.097 756.542 497.097 750.874 491.429L693.292 433.847 691.033 435.711C676.465 445.556 658.904 451.305 640 451.304 589.59 451.305 548.724 410.426 548.724 360 548.724 309.574 589.59 268.696 640 268.696Z"
+							fill="url(#fill-search-out-1)" fill-rule="evenodd" />
+					</g>
+				</svg>
+				<svg class="in" width="20" height="20" viewBox="0,0,134,134" xmlns="http://www.w3.org/2000/svg"
+					xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+					<defs>
+						<clipPath id="clip-search-in-0">
+							<rect x="573" y="293" width="134" height="134" />
+						</clipPath>
+						<linearGradient x1="611.068" y1="280.509" x2="668.932" y2="439.491"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-search-in-1">
+							<stop offset="0" stop-color="#82CDF6" />
+							<stop offset="0.18" stop-color="#82CDF6" />
+							<stop offset="0.91" stop-color="#4297D6" />
+							<stop offset="1" stop-color="#4297D6" />
+						</linearGradient>
+						<image width="132" height="132"
+							xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAMAAABmmnOVAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFZUExURQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKhZnwEAAABzdFJOUwABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj9AQUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVpbXF1eX2BhYmNkZWZnaGlqa2xtbm9wcXJv0gLZAAAACXBIWXMAAA7DAAAOwwHHb6hkAAARAklEQVR4XsWb91caWRTH2TQbFjoMvUlHmoKggihiw94Su8ZojInZ/P8/7Pfe9wZI1wjZ7zm7x8AM8zm3vpl5V/OHGvSMlde3tk5OLm9vzw8P19ZWpuMurfzyL2gotvjm5u7D+5vr63dXV28vLy+ELi/fnm6VRwflYd3TQKh2/unu9j0uf3lxfnZ6cnJ8fHR0yDo6Oj4+OT0735vy98vDu6CRscYtCG6uAXB2enx0+PrgYH9/b3d3h7S7u7u3v3/w+vDo+OTNbLgrBnkVnD+/B8G7txdnJ8e4/t7u9tbmxsb6+lpDaG1tfX1jc2sbLAdvjjYn3S/lqZ3Si+zV548f3l8TwdGbg72drY31xurK8tLiYr2+sLBQq+F/9fri0vLKagMo27v7rw83o8/l6Z2QPn94//HDzbvL85Oj1/u725vrjZWl+kJtvlqdrZTL5RlWuVyZna3O1xbqS8uraxtbO3sHy4kR+RNPVV/pw/3H25ury7Pjw4Pd7Y211eXFhflqpTwzVSoWJwuFPDSRzxcKk8ViaWqmXKnO1epLK431rZ397Uyf/JmnqDd3+vnj7fXVxSmMsLO5trpUr83NlqdLxUJ+YjyXzaTT6RQpnc5kstnceL4wCZJKdX5hcaWxsbW7En0yRnDj308fbhhhb3ujsVyvVSszU8XCRC6bTo0lE/FYLEqK4L9YPJ5IjqXSGZBMFqfLs/MLSytrmzszLvljfybT7O393ft3cAQhrC4tzFVmSpP58Wx6DJePhEOjwUAg4Gfhj2BwNBSORGOJZCqTnSiAo1qDOTY3Mnr5g38g7y15QiCsA6Fani7mxzOpJAHg+n6f1+N2u11C+Mvj9fr8gWAoHI0nxjK5icnSzOx8fbmxsW6XP/lYaafv7u9urs5P3jBCrVqempzIppPxKABwfbfL6XDYFUWxSSmK3e5wOl0ery8wGorEEqnMeL44XZlbWG6sJ/+oijrXvnz6cP327OhgB44AQqkwnhlLgMDv87iduLzNarGYTSaTUZXJZLZYrDbF7gCIPxiKxJOp7MTkVGWuvrJWMMsffoTGkBTv313ADFtry3DEFCHEo6Ggz+NyEgAubzTo9TqdbkSVTqc3GIxGM0CIA/YIRxPAKE7Pzi+uVr3ypx+qZ8V7uEKYYWVxvjI1SQiR0YDP7XIoVhgAALqR4eHhoaGhQVVDQ8PDQNEbjCYzOJxumIMwcvniTLW2tBr+R/78g9Rb+XL/4fry9BBmWKrNTk9OMILfCwKbRQLg4toBqL+pgQGtVguWYQIBhwIOXzAUTaZzhVJ5rr4aeyUv8AAN1b58uiVX7G6uLs6VS/ksI3icdiZgAC0u3tfX+436+vrAIkDAYbEqhBGOJTPjk9OzC8vJBxcu48q/YDg/PthZX1mozsATyWgoACsQAmxABAP9AOiBXrWLPgAJcwgMs9Xu9PhHI/FUNj9VmV9KD8mL/EavDv/9+P7q/Ohge225NjtVyKbi4aDP7VAsJoMeRlAJcNGXpBdS/I+XjAKLMAfcYrTY7C5vAD7JTBRn5urFF/Iyv9QQ7EAM+1uNpflyaYLMAE8Qgo4IyAkwAF/8udAzSP4pYAQIccAcRrPN4YJP4qlcYbpaTz3AI701ssMZMSzOzRTH04kImcFmNurhB9UGhEDXpMu3qwUCDsYYGtYZTAgNjz8UG8sWpmYX4r9d7Dwrf4EdzpAWq/Xq9GQuFQsFYAYrmYERWkYQl/2nTeITJgGHxIBT2Bhu3yhcki9Var/N1CLyAr7Y2wQDwiEZHZVmGB7UEgKM0CSQl5ZnauQ/mYNIyBw9PYQhjeENhhPpCVAE5Bk/0dj9PfICviCGfDYZCXpdMAM8oR0gBOEGuoi8pDxPSn5IYgxwkDXgEzaGJ4DAGC+Wq055/A/lPLn/oDJM5zPEgIikaGAzfIfwnV3lxyRhDXilp1cYg1ziDzHF5C9au3bt8931xfHBVoPskEFIepw2M0cDmwEIRMAI8pSfqokBp/T2IUBH9CarHRQxokj2yMO+1/SXjzeXJwfbjUVmCAc8DuGK/iYCXf/3BCw6UGCoxjBa7C7fKFFUfhoW8btP79+evtlZW5qbRkxGmMEwgohkBnIEIzyMQaV4Jij6mhSwxURpWpEHfaPeWwTE2eHu+vL8zCTFpMdhgx2QmL0UkJJBHvwgqRSMgfhkCooL5MjUjyvnLAUEknOlVi7mmAG+oHBQzfBYBjVOVWMgS1oUUz90SPD2483bk4Ot1YXZ0ngqirz4hoF+Tx77YDEEU7xAsrItKDrDiUyhaJLHtKl34/726gwBgaCcSMdGvU4bxcPTGL6iYFsM60xW1ItIMjcZ+7585/69u0al3FiamylkEiGfSzFTPDyRQaiNYnAYmerwBKNj46XvSlYfMgPZuYWAoKAMuBVLB+ygiikoMMgWepPN6R2NpScK38Zm6TMyg5whAgJBadShPnSGoWmLlz3I1BGDWXEhLLIFj/xWSn+KMnW8t7E8j2odD/kQEPph1IcOMbR5pG9ApEgADkl/fS+Sp6h8vb26UIEzwn43B0QHGVQKqhdIVIQFOST/VVQMH36kErG+hMwYE84YGRpAx+oYQ4uCw8JsY4cke+WXpBwMcfp6axVRqTpjSEtB2TmGJoUIC4sdGZIaby/eVx9vLlCvUSLGxygzzAY1IDrHwBRIEeqpCAur0xuKZ9LyKyj4+cPVKaUnSkR81OuwGHWUnR1mEBRNhyjuQGQsZ5BfaTTzSA1ExGK1BEP4XQplRl/vKwqITjKAghyCmgWHGCk245nm/enIOWoEUqNWJkN4HFSm0L1VQ8ijOiJhCsoQik2YohmaY/fvL4/3N5AaZAhEpW6ozRnyoM6o5RDEJpvCIr9poGsc7jQWKDVGvXaLYViUiM4ztGXIkN7EUSE7+sDnW7TwzeW5adSIgIvSUxqi4wyAoAwhUyBNOSqyopfGPt1cHO2u1SvFLLonUmNEpGcXGFRTUFSIBImmxLKieifCciafjgbdlBrUPNkQ/H1H1W4KrhVJN39+AG9QWJbGk2Gfy4buKVOjGxCtqIAp0MeCsRB9alG9QWHJ+SlqBIUln9ZhkSkoQQYGdVhY+CNjA/gweXd99oa9kYpSoWrPT3FahyVNgbKJDuINJSgoFm+vODemyBtOtM/BATU/xUmdljAFZ6lZ8QRjFBS7qFQo2bPFLLxBRYLWU2wIcU7HxRDoY/3kD5c/gkrx4uL6gitVIR1DbpjbioQ8qdPiBGEIyg9fKPJMY6AE3VqZR6USJbvb3pCm4FJhMGNZEe/V+KiLU4LmEmEfrahQqbpqCEgERa8s3dFhTYpDgsol9Q2sZrrtDYhMIeuVzemLGDUzVCWaIYG+gZLdxfwUEv6Q/SOkaNbQQUWViFDz0lEDZUN0G0Itmp5Rj2ZDxCVW2WE/Vwm1b3QX4hmKJlcKVG6PZgdxublMjYM6KKoEQkIs6+QJ3ZBMUix4TYor4NMcoF4iOYq5BK1w0UHRvLodEgLipSxXAb/miFoo18ugx25uQcjDuyPYmdsHp4c/oDnnoo0WGsP9BnUvlKruJigJphA9jGpmUPOWFvt1ytC/DPGc0wM56hvVvOXFBCCiAkJmqDy4W2pBoJsHNWe4/0OtwtLOj1UV34r/PQjkKCD8mjfcQ8WKRoXodly2Q2BJ4dXs/f8Qbs0mQci13f8E4dKsCoiJFO6E/ycIh2blB5b4m4GJZY1DU+LsIAg00b8NoR2iFDVrEpeoE4CgOiEh/mqxAoRO42EIWTH/DwiHV6vRidVdIcMLq79UttUGRr3D4evRvHhzvE8NjLsoQ1AX7ToEL63Eot+DazXobhitHOsJauW8qPkrEOpKl3a6zIqVVS4ZwqJGrKy6nh4cEuKeWHHRDpMorTHlnSjfkos1pji6S1IhhnRmxT2MD0y02pY3YLTQlYWiqw4RELTaRq3i53drR1wyUShQrXjJj6DoblTwaltmqHiyXDze40cksaDnb9wPQyIuxc2P08gfjYqHRblEiB8favu7DQEGNSSMNpfYPdpP6SEik26Im0HBX3ZBCDeCUG+I5Z7NWfVpkbgPHOjrbs0kCPXRgMWhbgELt56boVzRiw5+iCm/7bgkhHxIom70GdykoKBHqV6HlZ4pd+0pJosZeDGB+y+l+XJ0svmoBv6g904iSeW3nZZqCHjDbG+973DTWrdMjZTvBNWi2R0K9gbXbHrnQQ8xpbb58R2S1Oe08suOrtUrIKiVitaX7e/AYgfsjxS9/+rmQ35hB1mpKDfa958NLre/7uCn/AKi4xQCgosEwtL61YvqhPqEHU2MS4Vqik5TqIYQzevrXd0jK/QuEPWKn6eqpbsLFBSVFJZcJKzf7IxM7a7Rk5KEeLzd9oy9sxD4vVZ+Kjr5qaq+nU0OTZjCbtGLl2CdhxDOkIXK6vhuq390p4HSTS+gnPTepSsJIhnIGUgNhZZUX6t3hlopmQIFS9YKppDfd0DsCxGVlBqmH8w8uDYaC5ViDglCLwTFu/KOVixiYGdQVOLOq61YtpTZWJ6bztOeHt5GAodQsegYhWQQUYmFxLdRKdSz3qijdicjARdtGxgU+yc6RcEMzag0WpSfDKD411fmxdai9t0snaEQdqCoFNsnbD8d10ryJqsUmmnLIZ2haDKIXU5m5ecTMP2FVRmbtI+Ddzipew/lEX+opi9e9VJmGK2GX+xZNleXySG8owXVG3lKwflkijaGfg4Ic/temu/kXREOQYZgzUth0QGPtOIBiUEMPw8IoTA7RO4wEhRP9UiLgRKDtnp9Xyq/1j8xckg2GQ6gh/CmM0qRp1C0xwOqFAXlb3/pVZL2pWYSCE6iEB5BpjLGH4AIBBkPSE6zTfdMfvUL9aXr1al8Oh7yu5hisB+Z2qJ4BAYfLlzBuaklX9h+lRgtvSjVZ0sTKaSIoNBSvSCXPNYYzMA9i32BeNCbbaYH2IE0mFqolMaRIj63Xe5Obe5WJgx52O/EBBQNHJKUF2SH327kV9UXr1WKoAghLuSe6b5e2kBPxniIU/iQVjTwXmXkJtZSD/KF0MtwrSwpaNc0kkQa43kTQx75QzFBO4Pcta2MPNAXUoH5cjGHuPB7aJyAJxqI4kEYKkHTDBSSejD8rj58J2cetkjHwwGeL2lOFIgIbXpFSJ6iWkACcDBQcdDyTn6r+Q/mnPXJcnGCRky8LruVN/SL2Qo53UEc7SAtCQQQwArsCWEGwy/7xc/UE5jmYZtRBIZNjDbwlInAUDkgeXFI/Fs1Ao/ciFEXi23kESH5lYxTU4XcWCwcYGPwvA1bQ8wcCZAWC18dYhsgFEBAQz+EoChPmK8eDBQnx9MJGINGbsw0/EQDYDx9JTlI4uJ0eVyfCcgGYgyLrGDX/XyS4iEyxUoTWRgj6CWf8AyWmEMTHOoYlir6AAQqgk5vNFsV0w/X1Y/RS2emQMbgaTRYw6jX0TxcayCOBtCa4qE4Gs9rzqIptuFOzFRrPel8NkXTibCGYiVztCYD+4lFlRwPpEHFEZ3BaIYjrE/0REv9zqQckvS6aT7QzBOKACESGIWFP7Q0KTnM44k0J6k4rCOPmEj8rZ4pmVwLQ53V1OvUaU0S/lJHRk08MaoMPbTXPVTPDd4kDc6Ggn6v2yXmZmlu1WgADMlA86owAI2sKg6nYhh4XKN4oHotgVQqGYsQBw/wgsRmpRleksViseLyit3hdDnNQw9u2Y9Xv8kdGksQR4AmqV0uJ7NAdrvdQVPMbo9iHOxkJPxYPQb3aCwejfBQud/n83o9JK/X6/M6umqCb/VyyGj3eD3BwGgYFcTrcDjMuoE/aw8azX8p1DsCWPfRswAAAABJRU5ErkJggg=="
+							preserveAspectRatio="none" id="img2"></image>
+						<clipPath id="clip-search-in-3">
+							<rect x="574" y="294" width="132" height="132" />
+						</clipPath>
+					</defs>
+					<g clip-path="url(#clip-search-in-0)" transform="translate(-573 -293)">
+						<path
+							d="M574 360C574 323.549 603.549 294 640 294 676.451 294 706 323.549 706 360 706 396.451 676.451 426 640 426 603.549 426 574 396.451 574 360Z"
+							fill="url(#fill-search-in-1)" fill-rule="evenodd" />
+						<g clip-path="url(#clip-search-in-3)">
+							<use width="100%" height="100%" xlink:href="#img2" transform="translate(574 294)"></use>
+						</g>
+					</g>
+				</svg>
 			</a>
 			<a class="dock-btn" id="widgets-btn" win12_title="小组件" onclick="
 			if($('#widgets').hasClass('show')){
@@ -776,13 +1057,331 @@
 				}, 0);
 				$('#widgets-input').focus();
 			}">
-				<svg viewBox="0,0,260,260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden" class="wid1"><defs><clipPath id="clip-wid1-0"><rect x="510" y="230" width="260" height="260"/></clipPath><linearGradient x1="551.891" y1="207.391" x2="728.109" y2="512.609" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid1-1"><stop offset="0" stop-color="#7AB1FA"/><stop offset="0.18" stop-color="#7AB1FA"/><stop offset="0.91" stop-color="#4C6EDC"/><stop offset="1" stop-color="#4C6EDC"/></linearGradient></defs><g clip-path="url(#clip-wid1-0)" transform="translate(-510 -230)"><path d="M511 274.001C511 250.252 530.252 231 554.001 231L725.999 231C749.748 231 769 250.252 769 274.001L769 445.999C769 469.748 749.748 489 725.999 489L554.001 489C530.252 489 511 469.748 511 445.999Z" fill="url(#fill-wid1-1)" fill-rule="evenodd"/></g></svg>
-				<svg viewBox="0,0,175,206" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden" class="wid2"><defs><filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="5.81042 5.77778"/></filter><filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><clipPath id="clip-wid2-4"><rect x="615" y="214" width="175" height="206"/></clipPath><clipPath id="clip-wid2-5"><rect x="-6.53674" y="-6.5" width="101.068" height="115"/></clipPath><clipPath id="clip-wid2-6"><rect x="0" y="0" width="89" height="104"/></clipPath><linearGradient x1="644.325" y1="249.245" x2="754.675" y2="380.755" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid2-7"><stop offset="0" stop-color="#775CFE"/><stop offset="0.43" stop-color="#775CFE"/><stop offset="0.83" stop-color="#2473DC"/><stop offset="1" stop-color="#2473DC"/></linearGradient><clipPath id="clip-wid2-8"><rect x="-5" y="-5" width="67" height="42"/></clipPath><clipPath id="clip-wid2-9"><rect x="0" y="0" width="57" height="35"/></clipPath><clipPath id="clip-wid2-10"><rect x="-5" y="-5" width="103" height="42"/></clipPath><clipPath id="clip-wid2-11"><rect x="0" y="0" width="93" height="35"/></clipPath><clipPath id="clip-wid2-12"><rect x="-5" y="-5" width="80" height="42"/></clipPath><clipPath id="clip-wid2-13"><rect x="0" y="0" width="72" height="35"/></clipPath></defs><g clip-path="url(#clip-wid2-4)" transform="translate(-615 -214)"><g clip-path="url(#clip-wid2-5)" filter="url(#fx0)" transform="matrix(1.98876 0 0 2 614 213)"><g clip-path="url(#clip-wid2-6)"><path d="M18.2408 33.043C18.2408 24.8162 24.9475 18.1472 33.2208 18.1472L56.0574 18.1472C64.3306 18.1472 71.0374 24.8162 71.0374 33.043L71.0374 71.2513C71.0374 79.4781 64.3306 86.1472 56.0574 86.1472L33.2208 86.1472C24.9475 86.1472 18.2408 79.4781 18.2408 71.2513Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M647 276.792C647 260.338 660.338 247 676.792 247L722.208 247C738.662 247 752 260.338 752 276.792L752 353.208C752 369.662 738.662 383 722.208 383L676.792 383C660.338 383 647 369.662 647 353.208Z" fill="url(#fill-wid2-7)" fill-rule="evenodd"/><g clip-path="url(#clip-wid2-8)" filter="url(#fx1)" transform="translate(649 260)"><g clip-path="url(#clip-wid2-9)"><path d="M17.3857 17.3857 39.7776 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M664.5 275.5 686.892 275.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/><g clip-path="url(#clip-wid2-10)" filter="url(#fx2)" transform="translate(649 282)"><g clip-path="url(#clip-wid2-11)"><path d="M17.3857 17.3857 75.9099 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M664.5 297.5 723.024 297.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/><g clip-path="url(#clip-wid2-12)" filter="url(#fx3)" transform="translate(649 305)"><g clip-path="url(#clip-wid2-13)"><path d="M17.3857 17.3857 54.5358 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M664.5 320.5 701.65 320.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></svg>
-				<svg viewBox="0,0,174,298" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden" class="wid3"><defs><filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="5.81079 5.7971"/></filter><filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><clipPath id="clip-wid3-4"><rect x="498" y="214" width="174" height="298"/></clipPath><clipPath id="clip-wid3-5"><rect x="-6.53714" y="-6.52174" width="98.0572" height="162.04"/></clipPath><clipPath id="clip-wid3-6"><rect x="0" y="0" width="88" height="150"/></clipPath><linearGradient x1="668.609" y1="288.246" x2="496.391" y2="432.754" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid3-7"><stop offset="0" stop-color="#C45DD5"/><stop offset="0.18" stop-color="#C45DD5"/><stop offset="0.69" stop-color="#A266E4"/><stop offset="1" stop-color="#A266E4"/></linearGradient><clipPath id="clip-wid3-8"><rect x="-5" y="-5" width="86" height="42"/></clipPath><clipPath id="clip-wid3-9"><rect x="0" y="0" width="77" height="35"/></clipPath><clipPath id="clip-wid3-10"><rect x="-5" y="-5" width="67" height="42"/></clipPath><clipPath id="clip-wid3-11"><rect x="0" y="0" width="58" height="35"/></clipPath><clipPath id="clip-wid3-12"><rect x="-5" y="-5" width="92" height="42"/></clipPath><clipPath id="clip-wid3-13"><rect x="0" y="0" width="85" height="35"/></clipPath></defs><g clip-path="url(#clip-wid3-4)" transform="translate(-498 -214)"><g clip-path="url(#clip-wid3-5)" filter="url(#fx0)" transform="matrix(1.98864 0 0 1.99333 498 214)"><g clip-path="url(#clip-wid3-6)" transform="translate(2.84217e-14 -1.42109e-14)"><path d="M18.0166 36.3921C18.0166 26.2201 26.2821 17.9741 36.4781 17.9741L51.3493 17.9741C61.5454 17.9741 69.8109 26.2201 69.8109 36.3921L69.8109 113.436C69.8109 123.608 61.5454 131.854 51.3493 131.854L36.4781 131.854C26.2821 131.854 18.0166 123.608 18.0166 113.436Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M531 283.713C531 263.437 547.437 247 567.713 247L597.287 247C617.563 247 634 263.437 634 283.713L634 437.287C634 457.563 617.563 474 597.287 474L567.713 474C547.437 474 531 457.563 531 437.287Z" fill="url(#fill-wid3-7)" fill-rule="evenodd"/><g clip-path="url(#clip-wid3-8)" filter="url(#fx1)" transform="translate(534 259)"><g clip-path="url(#clip-wid3-9)"><path d="M17.3857 17.3857 59.5683 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M549.5 274.5 591.683 274.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/><g clip-path="url(#clip-wid3-10)" filter="url(#fx2)" transform="translate(534 281)"><g clip-path="url(#clip-wid3-11)"><path d="M17.3857 17.3857 40.3525 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M549.5 296.5 572.467 296.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/><g clip-path="url(#clip-wid3-12)" filter="url(#fx3)" transform="translate(534 302)"><g clip-path="url(#clip-wid3-13)"><path d="M17.3857 17.3857 67.3293 17.3858" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M549.5 317.5 599.444 317.5" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></svg>
-				<svg viewBox="0,0,141,113" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden" class="wid4"><defs><filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="5.77778 5.77778"/></filter><filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse" primitiveUnits="userSpaceOnUse"><feComponentTransfer color-interpolation-filters="sRGB"><feFuncR type="discrete" tableValues="0 0"/><feFuncG type="discrete" tableValues="0 0"/><feFuncB type="discrete" tableValues="0 0"/><feFuncA type="linear" slope="0.4" intercept="0"/></feComponentTransfer><feGaussianBlur stdDeviation="4 4"/></filter><clipPath id="clip-wid4-2"><rect x="629" y="380" width="141" height="113"/></clipPath><clipPath id="clip-wid4-3"><rect x="-6" y="-3" width="154" height="121"/></clipPath><clipPath id="clip-wid4-4"><rect x="0" y="0" width="143" height="115"/></clipPath><linearGradient x1="670.387" y1="386.075" x2="728.613" y2="486.925" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid4-5"><stop offset="0" stop-color="#D854CB"/><stop offset="0.13" stop-color="#D854CB"/><stop offset="1" stop-color="#A266E4"/></linearGradient><clipPath id="clip-wid4-6"><rect x="-5" y="-5" width="105" height="69"/></clipPath><clipPath id="clip-wid4-7"><rect x="0" y="0" width="98" height="63"/></clipPath></defs><g clip-path="url(#clip-wid4-2)" transform="translate(-629 -380)"><g clip-path="url(#clip-wid4-3)" filter="url(#fx0)" transform="translate(628 379)"><g clip-path="url(#clip-wid4-4)"><path d="M18.97 46.5177C18.97 31.4582 31.1781 19.25 46.2377 19.25L96.7623 19.25C111.822 19.25 124.03 31.4582 124.03 46.5177L124.03 68.4823C124.03 83.5418 111.822 95.75 96.7623 95.75L46.2377 95.75C31.1781 95.75 18.97 83.5418 18.97 68.4823Z" fill="#FF0000" fill-rule="evenodd"/></g></g><path d="M648 425.733C648 410.969 659.969 399 674.733 399L724.267 399C739.031 399 751 410.969 751 425.733L751 447.267C751 462.031 739.031 474 724.267 474L674.733 474C659.969 474 648 462.031 648 447.267Z" fill="url(#fill-wid4-5)" fill-rule="evenodd"/><g clip-path="url(#clip-wid4-6)" filter="url(#fx1)" transform="translate(653 407)"><g clip-path="url(#clip-wid4-7)"><path d="M17.3857 45.3857C24.6516 31.6825 31.9177 17.9794 39.5617 17.3963 47.2057 16.8131 56.4457 40.5542 63.2497 41.887 70.0537 43.2198 79.3357 31.3285 80.3857 25.3933" stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></g><path d="M668.5 450.5C675.766 436.797 683.032 423.094 690.676 422.511 698.32 421.928 707.56 445.669 714.364 447.001 721.168 448.334 730.45 436.443 731.5 430.508" stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd"/></g></svg>
+				<svg viewBox="0,0,260,260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+					overflow="hidden" class="wid1">
+					<defs>
+						<clipPath id="clip-wid1-0">
+							<rect x="510" y="230" width="260" height="260" />
+						</clipPath>
+						<linearGradient x1="551.891" y1="207.391" x2="728.109" y2="512.609"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid1-1">
+							<stop offset="0" stop-color="#7AB1FA" />
+							<stop offset="0.18" stop-color="#7AB1FA" />
+							<stop offset="0.91" stop-color="#4C6EDC" />
+							<stop offset="1" stop-color="#4C6EDC" />
+						</linearGradient>
+					</defs>
+					<g clip-path="url(#clip-wid1-0)" transform="translate(-510 -230)">
+						<path
+							d="M511 274.001C511 250.252 530.252 231 554.001 231L725.999 231C749.748 231 769 250.252 769 274.001L769 445.999C769 469.748 749.748 489 725.999 489L554.001 489C530.252 489 511 469.748 511 445.999Z"
+							fill="url(#fill-wid1-1)" fill-rule="evenodd" />
+					</g>
+				</svg>
+				<svg viewBox="0,0,175,206" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+					overflow="hidden" class="wid2">
+					<defs>
+						<filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="5.81042 5.77778" />
+						</filter>
+						<filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<clipPath id="clip-wid2-4">
+							<rect x="615" y="214" width="175" height="206" />
+						</clipPath>
+						<clipPath id="clip-wid2-5">
+							<rect x="-6.53674" y="-6.5" width="101.068" height="115" />
+						</clipPath>
+						<clipPath id="clip-wid2-6">
+							<rect x="0" y="0" width="89" height="104" />
+						</clipPath>
+						<linearGradient x1="644.325" y1="249.245" x2="754.675" y2="380.755"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid2-7">
+							<stop offset="0" stop-color="#775CFE" />
+							<stop offset="0.43" stop-color="#775CFE" />
+							<stop offset="0.83" stop-color="#2473DC" />
+							<stop offset="1" stop-color="#2473DC" />
+						</linearGradient>
+						<clipPath id="clip-wid2-8">
+							<rect x="-5" y="-5" width="67" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid2-9">
+							<rect x="0" y="0" width="57" height="35" />
+						</clipPath>
+						<clipPath id="clip-wid2-10">
+							<rect x="-5" y="-5" width="103" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid2-11">
+							<rect x="0" y="0" width="93" height="35" />
+						</clipPath>
+						<clipPath id="clip-wid2-12">
+							<rect x="-5" y="-5" width="80" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid2-13">
+							<rect x="0" y="0" width="72" height="35" />
+						</clipPath>
+					</defs>
+					<g clip-path="url(#clip-wid2-4)" transform="translate(-615 -214)">
+						<g clip-path="url(#clip-wid2-5)" filter="url(#fx0)" transform="matrix(1.98876 0 0 2 614 213)">
+							<g clip-path="url(#clip-wid2-6)">
+								<path
+									d="M18.2408 33.043C18.2408 24.8162 24.9475 18.1472 33.2208 18.1472L56.0574 18.1472C64.3306 18.1472 71.0374 24.8162 71.0374 33.043L71.0374 71.2513C71.0374 79.4781 64.3306 86.1472 56.0574 86.1472L33.2208 86.1472C24.9475 86.1472 18.2408 79.4781 18.2408 71.2513Z"
+									fill="#FF0000" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path
+							d="M647 276.792C647 260.338 660.338 247 676.792 247L722.208 247C738.662 247 752 260.338 752 276.792L752 353.208C752 369.662 738.662 383 722.208 383L676.792 383C660.338 383 647 369.662 647 353.208Z"
+							fill="url(#fill-wid2-7)" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid2-8)" filter="url(#fx1)" transform="translate(649 260)">
+							<g clip-path="url(#clip-wid2-9)">
+								<path d="M17.3857 17.3857 39.7776 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M664.5 275.5 686.892 275.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid2-10)" filter="url(#fx2)" transform="translate(649 282)">
+							<g clip-path="url(#clip-wid2-11)">
+								<path d="M17.3857 17.3857 75.9099 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M664.5 297.5 723.024 297.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid2-12)" filter="url(#fx3)" transform="translate(649 305)">
+							<g clip-path="url(#clip-wid2-13)">
+								<path d="M17.3857 17.3857 54.5358 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M664.5 320.5 701.65 320.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+					</g>
+				</svg>
+				<svg viewBox="0,0,174,298" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+					overflow="hidden" class="wid3">
+					<defs>
+						<filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="5.81079 5.7971" />
+						</filter>
+						<filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<filter id="fx2" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<filter id="fx3" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<clipPath id="clip-wid3-4">
+							<rect x="498" y="214" width="174" height="298" />
+						</clipPath>
+						<clipPath id="clip-wid3-5">
+							<rect x="-6.53714" y="-6.52174" width="98.0572" height="162.04" />
+						</clipPath>
+						<clipPath id="clip-wid3-6">
+							<rect x="0" y="0" width="88" height="150" />
+						</clipPath>
+						<linearGradient x1="668.609" y1="288.246" x2="496.391" y2="432.754"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid3-7">
+							<stop offset="0" stop-color="#C45DD5" />
+							<stop offset="0.18" stop-color="#C45DD5" />
+							<stop offset="0.69" stop-color="#A266E4" />
+							<stop offset="1" stop-color="#A266E4" />
+						</linearGradient>
+						<clipPath id="clip-wid3-8">
+							<rect x="-5" y="-5" width="86" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid3-9">
+							<rect x="0" y="0" width="77" height="35" />
+						</clipPath>
+						<clipPath id="clip-wid3-10">
+							<rect x="-5" y="-5" width="67" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid3-11">
+							<rect x="0" y="0" width="58" height="35" />
+						</clipPath>
+						<clipPath id="clip-wid3-12">
+							<rect x="-5" y="-5" width="92" height="42" />
+						</clipPath>
+						<clipPath id="clip-wid3-13">
+							<rect x="0" y="0" width="85" height="35" />
+						</clipPath>
+					</defs>
+					<g clip-path="url(#clip-wid3-4)" transform="translate(-498 -214)">
+						<g clip-path="url(#clip-wid3-5)" filter="url(#fx0)"
+							transform="matrix(1.98864 0 0 1.99333 498 214)">
+							<g clip-path="url(#clip-wid3-6)" transform="translate(2.84217e-14 -1.42109e-14)">
+								<path
+									d="M18.0166 36.3921C18.0166 26.2201 26.2821 17.9741 36.4781 17.9741L51.3493 17.9741C61.5454 17.9741 69.8109 26.2201 69.8109 36.3921L69.8109 113.436C69.8109 123.608 61.5454 131.854 51.3493 131.854L36.4781 131.854C26.2821 131.854 18.0166 123.608 18.0166 113.436Z"
+									fill="#FF0000" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path
+							d="M531 283.713C531 263.437 547.437 247 567.713 247L597.287 247C617.563 247 634 263.437 634 283.713L634 437.287C634 457.563 617.563 474 597.287 474L567.713 474C547.437 474 531 457.563 531 437.287Z"
+							fill="url(#fill-wid3-7)" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid3-8)" filter="url(#fx1)" transform="translate(534 259)">
+							<g clip-path="url(#clip-wid3-9)">
+								<path d="M17.3857 17.3857 59.5683 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M549.5 274.5 591.683 274.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid3-10)" filter="url(#fx2)" transform="translate(534 281)">
+							<g clip-path="url(#clip-wid3-11)">
+								<path d="M17.3857 17.3857 40.3525 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M549.5 296.5 572.467 296.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid3-12)" filter="url(#fx3)" transform="translate(534 302)">
+							<g clip-path="url(#clip-wid3-13)">
+								<path d="M17.3857 17.3857 67.3293 17.3858" stroke="#FFFFFF" stroke-width="9"
+									stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path d="M549.5 317.5 599.444 317.5" stroke="#FFFFFF" stroke-width="8.66667"
+							stroke-linecap="round" stroke-miterlimit="8" fill="none" fill-rule="evenodd" />
+					</g>
+				</svg>
+				<svg viewBox="0,0,141,113" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+					overflow="hidden" class="wid4">
+					<defs>
+						<filter id="fx0" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="5.77778 5.77778" />
+						</filter>
+						<filter id="fx1" x="-10%" y="-10%" width="120%" height="120%" filterUnits="userSpaceOnUse"
+							primitiveUnits="userSpaceOnUse">
+							<feComponentTransfer color-interpolation-filters="sRGB">
+								<feFuncR type="discrete" tableValues="0 0" />
+								<feFuncG type="discrete" tableValues="0 0" />
+								<feFuncB type="discrete" tableValues="0 0" />
+								<feFuncA type="linear" slope="0.4" intercept="0" />
+							</feComponentTransfer>
+							<feGaussianBlur stdDeviation="4 4" />
+						</filter>
+						<clipPath id="clip-wid4-2">
+							<rect x="629" y="380" width="141" height="113" />
+						</clipPath>
+						<clipPath id="clip-wid4-3">
+							<rect x="-6" y="-3" width="154" height="121" />
+						</clipPath>
+						<clipPath id="clip-wid4-4">
+							<rect x="0" y="0" width="143" height="115" />
+						</clipPath>
+						<linearGradient x1="670.387" y1="386.075" x2="728.613" y2="486.925"
+							gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="fill-wid4-5">
+							<stop offset="0" stop-color="#D854CB" />
+							<stop offset="0.13" stop-color="#D854CB" />
+							<stop offset="1" stop-color="#A266E4" />
+						</linearGradient>
+						<clipPath id="clip-wid4-6">
+							<rect x="-5" y="-5" width="105" height="69" />
+						</clipPath>
+						<clipPath id="clip-wid4-7">
+							<rect x="0" y="0" width="98" height="63" />
+						</clipPath>
+					</defs>
+					<g clip-path="url(#clip-wid4-2)" transform="translate(-629 -380)">
+						<g clip-path="url(#clip-wid4-3)" filter="url(#fx0)" transform="translate(628 379)">
+							<g clip-path="url(#clip-wid4-4)">
+								<path
+									d="M18.97 46.5177C18.97 31.4582 31.1781 19.25 46.2377 19.25L96.7623 19.25C111.822 19.25 124.03 31.4582 124.03 46.5177L124.03 68.4823C124.03 83.5418 111.822 95.75 96.7623 95.75L46.2377 95.75C31.1781 95.75 18.97 83.5418 18.97 68.4823Z"
+									fill="#FF0000" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path
+							d="M648 425.733C648 410.969 659.969 399 674.733 399L724.267 399C739.031 399 751 410.969 751 425.733L751 447.267C751 462.031 739.031 474 724.267 474L674.733 474C659.969 474 648 462.031 648 447.267Z"
+							fill="url(#fill-wid4-5)" fill-rule="evenodd" />
+						<g clip-path="url(#clip-wid4-6)" filter="url(#fx1)" transform="translate(653 407)">
+							<g clip-path="url(#clip-wid4-7)">
+								<path
+									d="M17.3857 45.3857C24.6516 31.6825 31.9177 17.9794 39.5617 17.3963 47.2057 16.8131 56.4457 40.5542 63.2497 41.887 70.0537 43.2198 79.3357 31.3285 80.3857 25.3933"
+									stroke="#FFFFFF" stroke-width="9" stroke-linecap="round" stroke-miterlimit="8"
+									fill="none" fill-rule="evenodd" />
+							</g>
+						</g>
+						<path
+							d="M668.5 450.5C675.766 436.797 683.032 423.094 690.676 422.511 698.32 421.928 707.56 445.669 714.364 447.001 721.168 448.334 730.45 436.443 731.5 430.508"
+							stroke="#FFFFFF" stroke-width="8.66667" stroke-linecap="round" stroke-miterlimit="8"
+							fill="none" fill-rule="evenodd" />
+					</g>
+				</svg>
 			</a>
-			<a class="dock-btn" onclick="$('#copilot').toggleClass('show');$(this).toggleClass('show')" id="copilot-btn">
-			<img src="icon/copilot.svg"></a>
+			<a class="dock-btn" onclick="$('#copilot').toggleClass('show');$(this).toggleClass('show')"
+				id="copilot-btn">
+				<img src="icon/copilot.svg"></a>
 		</div>
 		<div class="dock" id="taskbar" style="display: none;" count="0">
 		</div>
@@ -790,8 +1389,45 @@
 
 		</div>
 		<div class="a dock theme" win12_title="切换主题" onclick="toggletheme()">
-			<svg viewBox="0,0,307,307" class="light" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="theme-light-clip0"><rect x="79" y="77" width="307" height="307" /></clipPath><linearGradient x1="128.499" y1="49.9991" x2="337.501" y2="412.001" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="theme-light-fill1"><stop offset="0" stop-color="#FFC567" /><stop offset="0.18" stop-color="#FFC567" /><stop offset="0.8" stop-color="#EE54F2" /></linearGradient></defs><g clip-path="url(#theme-light-clip0)" transform="translate(-79 -77)"><path d="M80 231C80 146.5 148.5 78 233 78 317.5 78 386 146.5 386 231 386 315.5 317.5 384 233 384 148.5 384 80 315.5 80 231Z" fill="url(#theme-light-fill1)" fill-rule="evenodd" /></g></svg>
-			<svg viewBox="0,0,275,294" class="dark" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="theme-dark-clip0"><rect x="525" y="230" width="275" height="294" /></clipPath><linearGradient x1="599.492" y1="203.887" x2="725.508" y2="550.113" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="theme-dark-fill1"><stop offset="0" stop-color="#2474B6" /><stop offset="0.42" stop-color="#2474B6" /><stop offset="0.98" stop-color="#FFD966" /><stop offset="1" stop-color="#FFD966" /></linearGradient></defs><g clip-path="url(#theme-dark-clip0)" transform="translate(-525 -230)"><path d="M635.002 236.062C638.664 240.491 639.245 246.694 636.469 251.721 625.869 271.094 620.334 292.809 620.372 314.869 620.372 388.255 680.469 447.679 754.537 447.679 764.199 447.679 773.604 446.675 782.643 444.759 788.307 443.538 794.156 445.809 797.493 450.526 801.036 455.459 800.803 462.148 796.925 466.824 767.803 502.434 724.103 523.073 677.976 523 593.458 523 525 455.217 525 371.701 525 308.846 563.757 254.933 618.942 232.083 624.588 229.708 631.132 231.329 635.002 236.062Z" fill="url(#theme-dark-fill1)" fill-rule="evenodd" /></g></svg>
+			<svg viewBox="0,0,307,307" class="light" xmlns="http://www.w3.org/2000/svg"
+				xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+				<defs>
+					<clipPath id="theme-light-clip0">
+						<rect x="79" y="77" width="307" height="307" />
+					</clipPath>
+					<linearGradient x1="128.499" y1="49.9991" x2="337.501" y2="412.001" gradientUnits="userSpaceOnUse"
+						spreadMethod="reflect" id="theme-light-fill1">
+						<stop offset="0" stop-color="#FFC567" />
+						<stop offset="0.18" stop-color="#FFC567" />
+						<stop offset="0.8" stop-color="#EE54F2" />
+					</linearGradient>
+				</defs>
+				<g clip-path="url(#theme-light-clip0)" transform="translate(-79 -77)">
+					<path
+						d="M80 231C80 146.5 148.5 78 233 78 317.5 78 386 146.5 386 231 386 315.5 317.5 384 233 384 148.5 384 80 315.5 80 231Z"
+						fill="url(#theme-light-fill1)" fill-rule="evenodd" />
+				</g>
+			</svg>
+			<svg viewBox="0,0,275,294" class="dark" xmlns="http://www.w3.org/2000/svg"
+				xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+				<defs>
+					<clipPath id="theme-dark-clip0">
+						<rect x="525" y="230" width="275" height="294" />
+					</clipPath>
+					<linearGradient x1="599.492" y1="203.887" x2="725.508" y2="550.113" gradientUnits="userSpaceOnUse"
+						spreadMethod="reflect" id="theme-dark-fill1">
+						<stop offset="0" stop-color="#2474B6" />
+						<stop offset="0.42" stop-color="#2474B6" />
+						<stop offset="0.98" stop-color="#FFD966" />
+						<stop offset="1" stop-color="#FFD966" />
+					</linearGradient>
+				</defs>
+				<g clip-path="url(#theme-dark-clip0)" transform="translate(-525 -230)">
+					<path
+						d="M635.002 236.062C638.664 240.491 639.245 246.694 636.469 251.721 625.869 271.094 620.334 292.809 620.372 314.869 620.372 388.255 680.469 447.679 754.537 447.679 764.199 447.679 773.604 446.675 782.643 444.759 788.307 443.538 794.156 445.809 797.493 450.526 801.036 455.459 800.803 462.148 796.925 466.824 767.803 502.434 724.103 523.073 677.976 523 593.458 523 525 455.217 525 371.701 525 308.846 563.757 254.933 618.942 232.083 624.588 229.708 631.132 231.329 635.002 236.062Z"
+						fill="url(#theme-dark-fill1)" fill-rule="evenodd" />
+				</g>
+			</svg>
 		</div>
 		<div class="a dock control" onclick="if($('#control').hasClass('show')) {
 			$('#control').removeClass('show');
@@ -1228,7 +1864,36 @@
 		<div class="content" id="win-setting">
 			<div class="menu">
 				<a class="a user">
-					<svg viewBox="0,0,257,344" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden"><defs><clipPath id="user-clip1"><rect x="382" y="195" width="257" height="344" /></clipPath><linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill3"><stop offset="0" stop-color="#A964C8" /><stop offset="0.35" stop-color="#A964C8" /><stop offset="0.87" stop-color="#2D8AD5" /><stop offset="1" stop-color="#2D8AD5" /></linearGradient><linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422" gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill4"><stop offset="0" stop-color="#A964C8" /><stop offset="0.35" stop-color="#A964C8" /><stop offset="0.87" stop-color="#2D8AD5" /><stop offset="1" stop-color="#2D8AD5" /></linearGradient></defs><g clip-path="url(#user-clip1)" transform="translate(-382 -195)"><path d="M637.755 433.872C642.215 515.221 579.577 537.983 508.011 537.983 436.444 537.983 376.676 507.833 383.513 437.11 383.109 425.234 389.59 414.133 398.634 409.891 413.82 402.768 444.753 402.936 507.484 402.997 570.214 403.058 609.164 402.279 621.521 407.947 633.878 413.614 638.011 424.609 637.755 433.872Z" fill="url(#user-fill3)" fill-rule="evenodd" /><path d="M422 285C422 235.847 461.623 196 510.5 196 559.377 196 599 235.847 599 285 599 334.153 559.377 374 510.5 374 461.623 374 422 334.153 422 285Z" fill="url(#user-fill4)" fill-rule="evenodd" /></g></svg>
+					<svg viewBox="0,0,257,344" xmlns="http://www.w3.org/2000/svg"
+						xmlns:xlink="http://www.w3.org/1999/xlink" overflow="hidden">
+						<defs>
+							<clipPath id="user-clip1">
+								<rect x="382" y="195" width="257" height="344" />
+							</clipPath>
+							<linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422"
+								gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill3">
+								<stop offset="0" stop-color="#A964C8" />
+								<stop offset="0.35" stop-color="#A964C8" />
+								<stop offset="0.87" stop-color="#2D8AD5" />
+								<stop offset="1" stop-color="#2D8AD5" />
+							</linearGradient>
+							<linearGradient x1="351.462" y1="233.56" x2="669.496" y2="500.422"
+								gradientUnits="userSpaceOnUse" spreadMethod="reflect" id="user-fill4">
+								<stop offset="0" stop-color="#A964C8" />
+								<stop offset="0.35" stop-color="#A964C8" />
+								<stop offset="0.87" stop-color="#2D8AD5" />
+								<stop offset="1" stop-color="#2D8AD5" />
+							</linearGradient>
+						</defs>
+						<g clip-path="url(#user-clip1)" transform="translate(-382 -195)">
+							<path
+								d="M637.755 433.872C642.215 515.221 579.577 537.983 508.011 537.983 436.444 537.983 376.676 507.833 383.513 437.11 383.109 425.234 389.59 414.133 398.634 409.891 413.82 402.768 444.753 402.936 507.484 402.997 570.214 403.058 609.164 402.279 621.521 407.947 633.878 413.614 638.011 424.609 637.755 433.872Z"
+								fill="url(#user-fill3)" fill-rule="evenodd" />
+							<path
+								d="M422 285C422 235.847 461.623 196 510.5 196 559.377 196 599 235.847 599 285 599 334.153 559.377 374 510.5 374 461.623 374 422 334.153 422 285Z"
+								fill="url(#user-fill4)" fill-rule="evenodd" />
+						</g>
+					</svg>
 					<div>
 						<p>瓶盖</p>
 						<p>tanjingyuan@win12.com</p>
@@ -1249,7 +1914,8 @@
 					<a><img src="apps/icons/setting/game.png">游戏</a>
 					<a><img src="apps/icons/setting/help.png">辅助功能</a>
 					<a><img src="apps/icons/setting/safe.png">隐私和安全性</a>
-					<a class="enable update" onclick="apps.setting.page('update')"><img src="apps/icons/setting/update.png">Windows 更新</a>
+					<a class="enable update" onclick="apps.setting.page('update')"><img
+							src="apps/icons/setting/update.png">Windows 更新</a>
 					<span class="focs"></span>
 				</list>
 			</div>
@@ -1265,20 +1931,104 @@
 						</div>
 					</div>
 					<div class="setting-list">
-						<a><icon></icon><div><p>显示</p><p>显示器、亮度、夜间模式、显示描述</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>声音</p><p>声音级别、输入、输出、声音设备</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>通知</p><p>来自系统和应用的警报</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>专注助手</p><p>通知、自动规则</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon class="b">&#xF186;</icon><div><p>电源</p><p>睡眠、电池使用情况、节电模式</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>存储</p><p>存储空间、驱动器、配置规则</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>多任务处理</p><p>贴靠窗口、桌面、任务切换</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>激活</p><p>激活状态、订阅、产品密钥</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>疑难解答</p><p>建议的疑难解答、首选项和历史记录</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>恢复</p><p>重置、高级启动、返回</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>投影到此电脑</p><p>权限、配对 PIN、可发现性</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>远程桌面</p><p>远程桌面用户、连接权限</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>剪贴板</p><p>剪贴和复制历史记录、同步、清除</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon></icon><div><p>关于</p><p>设备规格、重命名电脑、Windows 规格</p></div><i class="bi bi-chevron-right"></i></a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>显示</p>
+								<p>显示器、亮度、夜间模式、显示描述</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>声音</p>
+								<p>声音级别、输入、输出、声音设备</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>通知</p>
+								<p>来自系统和应用的警报</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>专注助手</p>
+								<p>通知、自动规则</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon class="b">&#xF186;</icon>
+							<div>
+								<p>电源</p>
+								<p>睡眠、电池使用情况、节电模式</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>存储</p>
+								<p>存储空间、驱动器、配置规则</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>多任务处理</p>
+								<p>贴靠窗口、桌面、任务切换</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>激活</p>
+								<p>激活状态、订阅、产品密钥</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>疑难解答</p>
+								<p>建议的疑难解答、首选项和历史记录</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>恢复</p>
+								<p>重置、高级启动、返回</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>投影到此电脑</p>
+								<p>权限、配对 PIN、可发现性</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>远程桌面</p>
+								<p>远程桌面用户、连接权限</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>剪贴板</p>
+								<p>剪贴和复制历史记录、同步、清除</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon></icon>
+							<div>
+								<p>关于</p>
+								<p>设备规格、重命名电脑、Windows 规格</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
 					</div>
 				</div>
 				<div class="cnt appearance">
@@ -1316,8 +2066,17 @@
 									setData('color2',$('div.app-color>div>input.theme2inp').val())">应用</a>
 							</div>
 						</div>
-						<a class="dp theme" onclick="$('.dp.theme').toggleClass('show');if ($('#set-theme>.a').length) return;apps.setting.theme_get();">
-							<icon>&#xE771;</icon><div><p>主题</p><p>设置 Windows 的主题 想要<span class="a jump" win12_title="https://github.com/tjy-gitnub/win12-theme" onclick="window.open('https://github.com/tjy-gitnub/win12-theme','_blank')">上传自己的主题</span>?</p></div><i class="bi bi-chevron-down"></i></a>
+						<a class="dp theme"
+							onclick="$('.dp.theme').toggleClass('show');if ($('#set-theme>.a').length) return;apps.setting.theme_get();">
+							<icon>&#xE771;</icon>
+							<div>
+								<p>主题</p>
+								<p>设置 Windows 的主题 想要<span class="a jump"
+										win12_title="https://github.com/tjy-gitnub/win12-theme"
+										onclick="window.open('https://github.com/tjy-gitnub/win12-theme','_blank')">上传自己的主题</span>?
+								</p>
+							</div><i class="bi bi-chevron-down"></i>
+						</a>
 						<div class="dp theme" id="set-theme">
 							<loading>
 								<svg width="30px" height="30px" viewBox="0 0 16 16">
@@ -1327,29 +2086,60 @@
 								</svg>
 							</loading>
 						</div>
-						<div class="border-radius"><icon></icon><div><p>圆角</p><p>设置系统界面中是否启用圆角</p></div>
+						<div class="border-radius">
+							<icon></icon>
+							<div>
+								<p>圆角</p>
+								<p>设置系统界面中是否启用圆角</p>
+							</div>
 							<div class="alr">
-								<a class="a checkbox checked" onclick="$(this).toggleClass('checked');$(':root').toggleClass('nobr')"></a>
+								<a class="a checkbox checked"
+									onclick="$(this).toggleClass('checked');$(':root').toggleClass('nobr')"></a>
 							</div>
 						</div>
-						<div class="border-radius"><icon></icon><div><p>动画</p><p>系统界面元素过渡动画</p></div>
+						<div class="border-radius">
+							<icon></icon>
+							<div>
+								<p>动画</p>
+								<p>系统界面元素过渡动画</p>
+							</div>
 							<div class="alr">
-								<a class="a checkbox checked" onclick="$(this).toggleClass('checked');$(':root').toggleClass('notrans')"></a>
+								<a class="a checkbox checked"
+									onclick="$(this).toggleClass('checked');$(':root').toggleClass('notrans')"></a>
 							</div>
 						</div>
-						<div class="border-radius"><icon></icon><div><p>阴影</p><p>为系统界面元素添加阴影效果</p></div>
+						<div class="border-radius">
+							<icon></icon>
+							<div>
+								<p>阴影</p>
+								<p>为系统界面元素添加阴影效果</p>
+							</div>
 							<div class="alr">
-								<a class="a checkbox checked" onclick="$(this).toggleClass('checked');$(':root').toggleClass('nosd')"></a>
+								<a class="a checkbox checked"
+									onclick="$(this).toggleClass('checked');$(':root').toggleClass('nosd')"></a>
 							</div>
 						</div>
-						<div class="border-radius"><icon></icon><div><p>多窗口透明</p><p>为所有窗口开启透明效果，而不是仅用于焦点窗口 <span class="a jump" win12_title="开启后将占用大量GPU,可能造成卡顿">详细</span></p></div>
+						<div class="border-radius">
+							<icon></icon>
+							<div>
+								<p>多窗口透明</p>
+								<p>为所有窗口开启透明效果，而不是仅用于焦点窗口 <span class="a jump"
+										win12_title="开启后将占用大量GPU,可能造成卡顿">详细</span></p>
+							</div>
 							<div class="alr">
-								<a class="a checkbox" onclick="$(this).toggleClass('checked');$(':root').toggleClass('moreblur')"></a>
+								<a class="a checkbox"
+									onclick="$(this).toggleClass('checked');$(':root').toggleClass('moreblur')"></a>
 							</div>
 						</div>
-						<div class="border-radius"><icon>&#xE621;</icon><div><p>Mica效果 (实验)</p><p>为焦点窗口开启mica效果 <a class="a jump" onclick="shownotice('feedback')">反馈</a></p></div>
+						<div class="border-radius">
+							<icon>&#xE621;</icon>
+							<div>
+								<p>Mica效果 (实验)</p>
+								<p>为焦点窗口开启mica效果 <a class="a jump" onclick="shownotice('feedback')">反馈</a></p>
+							</div>
 							<div class="alr">
-								<a class="a checkbox" onclick="$(this).toggleClass('checked');$(':root').toggleClass('mica')"></a>
+								<a class="a checkbox"
+									onclick="$(this).toggleClass('checked');$(':root').toggleClass('mica')"></a>
 							</div>
 						</div>
 					</div>
@@ -1357,16 +2147,90 @@
 				<div class="cnt update">
 					<p class="title">Windows 更新</p>
 					<div class="lo">
-						<svg viewBox="0 0 65 65"version="1.1"id="svg5"xmlns:xlink="http://www.w3.org/1999/xlink"xmlns="http://www.w3.org/2000/svg"xmlns:svg="http://www.w3.org/2000/svg"><defs id="defs2"><linearGradient id="linearGradient12966"><stop style="stop-color:#1946ff;stop-opacity:1;"offset="0"id="stop12962"/><stop style="stop-color:#3eddff;stop-opacity:1;"offset="1"id="stop12964"/></linearGradient><linearGradient id="linearGradient10659"><stop style="stop-color:#6c00e8;stop-opacity:1;"offset="0"id="stop10655"/><stop style="stop-color:#d05ed6;stop-opacity:1;"offset="1"id="stop10657"/></linearGradient><linearGradient xlink:href="#linearGradient10659"id="linearGradient10661"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"gradientUnits="userSpaceOnUse"/><linearGradient xlink:href="#linearGradient10659"id="linearGradient12869"gradientUnits="userSpaceOnUse"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"/><linearGradient xlink:href="#linearGradient10659"id="linearGradient12871"gradientUnits="userSpaceOnUse"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"/><linearGradient xlink:href="#linearGradient12966"id="linearGradient12968"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"gradientUnits="userSpaceOnUse"/><linearGradient xlink:href="#linearGradient12966"id="linearGradient13788"gradientUnits="userSpaceOnUse"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"/><linearGradient xlink:href="#linearGradient12966"id="linearGradient13790"gradientUnits="userSpaceOnUse"x1="40.558044"y1="64.876854"x2="103.16348"y2="64.876854"/></defs><g id="layer1"><g id="g8420"transform="rotate(-173.25016,50.599831,57.584909)"style="stroke:url(#linearGradient10661)"><path style="fill:none;stroke:url(#linearGradient12869);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"id="path234-2"d="M 43.058046,79.121117 A 28.487005,28.487005 0 0 1 66.602472,51.066164 28.487005,28.487005 0 0 1 98.316952,69.38588"/><path style="fill:none;stroke:url(#linearGradient12871);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"d="M 85.756154,73.849626 100.66351,72.185133 98.999027,57.27777"id="path1617-6"/></g><g id="g8420-2"transform="rotate(6.74984,459.81282,-281.39813)"style="stroke:url(#linearGradient12968);stroke-opacity:1"><path style="fill:none;stroke:url(#linearGradient13788);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"id="path234-2-2"d="M 43.058046,79.121117 A 28.487005,28.487005 0 0 1 66.602472,51.066164 28.487005,28.487005 0 0 1 98.316952,69.38588"/><path style="fill:none;stroke:url(#linearGradient13790);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"d="M 85.756154,73.849626 100.66351,72.185133 98.999027,57.27777"id="path1617-6-0"/></g></g></svg>
+						<svg viewBox="0 0 65 65" version="1.1" id="svg5" xmlns:xlink="http://www.w3.org/1999/xlink"
+							xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+							<defs id="defs2">
+								<linearGradient id="linearGradient12966">
+									<stop style="stop-color:#1946ff;stop-opacity:1;" offset="0" id="stop12962" />
+									<stop style="stop-color:#3eddff;stop-opacity:1;" offset="1" id="stop12964" />
+								</linearGradient>
+								<linearGradient id="linearGradient10659">
+									<stop style="stop-color:#6c00e8;stop-opacity:1;" offset="0" id="stop10655" />
+									<stop style="stop-color:#d05ed6;stop-opacity:1;" offset="1" id="stop10657" />
+								</linearGradient>
+								<linearGradient xlink:href="#linearGradient10659" id="linearGradient10661"
+									x1="40.558044" y1="64.876854" x2="103.16348" y2="64.876854"
+									gradientUnits="userSpaceOnUse" />
+								<linearGradient xlink:href="#linearGradient10659" id="linearGradient12869"
+									gradientUnits="userSpaceOnUse" x1="40.558044" y1="64.876854" x2="103.16348"
+									y2="64.876854" />
+								<linearGradient xlink:href="#linearGradient10659" id="linearGradient12871"
+									gradientUnits="userSpaceOnUse" x1="40.558044" y1="64.876854" x2="103.16348"
+									y2="64.876854" />
+								<linearGradient xlink:href="#linearGradient12966" id="linearGradient12968"
+									x1="40.558044" y1="64.876854" x2="103.16348" y2="64.876854"
+									gradientUnits="userSpaceOnUse" />
+								<linearGradient xlink:href="#linearGradient12966" id="linearGradient13788"
+									gradientUnits="userSpaceOnUse" x1="40.558044" y1="64.876854" x2="103.16348"
+									y2="64.876854" />
+								<linearGradient xlink:href="#linearGradient12966" id="linearGradient13790"
+									gradientUnits="userSpaceOnUse" x1="40.558044" y1="64.876854" x2="103.16348"
+									y2="64.876854" />
+							</defs>
+							<g id="layer1">
+								<g id="g8420" transform="rotate(-173.25016,50.599831,57.584909)"
+									style="stroke:url(#linearGradient10661)">
+									<path
+										style="fill:none;stroke:url(#linearGradient12869);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+										id="path234-2"
+										d="M 43.058046,79.121117 A 28.487005,28.487005 0 0 1 66.602472,51.066164 28.487005,28.487005 0 0 1 98.316952,69.38588" />
+									<path
+										style="fill:none;stroke:url(#linearGradient12871);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+										d="M 85.756154,73.849626 100.66351,72.185133 98.999027,57.27777"
+										id="path1617-6" />
+								</g>
+								<g id="g8420-2" transform="rotate(6.74984,459.81282,-281.39813)"
+									style="stroke:url(#linearGradient12968);stroke-opacity:1">
+									<path
+										style="fill:none;stroke:url(#linearGradient13788);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+										id="path234-2-2"
+										d="M 43.058046,79.121117 A 28.487005,28.487005 0 0 1 66.602472,51.066164 28.487005,28.487005 0 0 1 98.316952,69.38588" />
+									<path
+										style="fill:none;stroke:url(#linearGradient13790);stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+										d="M 85.756154,73.849626 100.66351,72.185133 98.999027,57.27777"
+										id="path1617-6-0" />
+								</g>
+							</g>
+						</svg>
 						<div>
 							<p>Windows 12 目前是最新版本</p>
 							<p class="detail">有更新可用时将会在此显示(有点困难，以后再完善，目前不能用)</p>
 						</div>
 					</div>
 					<div class="setting-list">
-						<div><icon>&#xE794;</icon><div><p>更新已就绪 (别按按钮，否则后果自负！</p><p>v7.0.0</p></div><div class="alr"><a class="a button" style="font-size: 16px;margin-top: -7.5px;" onclick="sendToSw({head:'update'})">更新</a></div></div>
-						<a><icon>&#xE946;</icon><div><p>历史版本</p><p>查看历史版本功能</p></div><i class="bi bi-chevron-right"></i></a>
-						<a><icon>&#xE896;</icon><div><p>下载完整内容</p><p>当更新或系统出现问题，使用此项下载最新完整内容</p></div><i class="bi bi-chevron-right"></i></a>
+						<div>
+							<icon>&#xE794;</icon>
+							<div>
+								<p>更新已就绪 (别按按钮，否则后果自负！</p>
+								<p>v7.0.0</p>
+							</div>
+							<div class="alr"><a class="a button" style="font-size: 16px;margin-top: -7.5px;"
+									onclick="sendToSw({head:'update'})">更新</a></div>
+						</div>
+						<a>
+							<icon>&#xE946;</icon>
+							<div>
+								<p>历史版本</p>
+								<p>查看历史版本功能</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
+						<a>
+							<icon>&#xE896;</icon>
+							<div>
+								<p>下载完整内容</p>
+								<p>当更新或系统出现问题，使用此项下载最新完整内容</p>
+							</div><i class="bi bi-chevron-right"></i>
+						</a>
 					</div>
 				</div>
 			</div>
@@ -1487,7 +2351,7 @@
 					onclick="if($('#calc-input').val().length > 1) { $('#calc-input').val($('#calc-input')[0].value.substring(0,$('#calc-input')[0].value.length-1)); } else { $('#calc-input').val('0'); }"><i
 						class="bi bi-backspace"></i></a>
 				<a class="a b ans u"
-					onclick="$('#calc-input')[0].value=eval($('#calc-input')[0].value.replace('÷', '/').replace('×', '*'))">
+					onclick="$('#calc-input').val(math.format(math.evaluate($('#calc-input').val().replace('÷', '/').replace('×', '*')), { precision: 14 }));">
 					=</a>
 			</div>
 		</div>
@@ -1560,26 +2424,30 @@
 			<div class="cnt update">
 				<h1 class="tit"><span></span>更新记录</h1>
 				<div style="margin-left: 20px;">
-					<details><summary><span>v7.0.1</span> 资源管理器标签页、离线界面与新闻</summary><p>
-						&emsp;&emsp;-文件资源管理器的标签页(来自 @tjy-gitnub)<br />
-						&emsp;&emsp;-新增了Microsoft Edge浏览器的离线界面(来自 @User782Tec)<br />
-						&emsp;&emsp;-新增新闻(来自 @Nick-DL)<br />
-						&emsp;&emsp;-优化部分UI<br />
-						&emsp;&emsp;-细节优化和修复</p>
+					<details>
+						<summary><span>v7.0.1</span> 资源管理器标签页、离线界面与新闻</summary>
+						<p>
+							&emsp;&emsp;-文件资源管理器的标签页(来自 @tjy-gitnub)<br />
+							&emsp;&emsp;-新增了Microsoft Edge浏览器的离线界面(来自 @User782Tec)<br />
+							&emsp;&emsp;-新增新闻(来自 @Nick-DL)<br />
+							&emsp;&emsp;-优化部分UI<br />
+							&emsp;&emsp;-细节优化和修复</p>
 					</details>
-					<details><summary><span>v7.0.0</span> AI助手,新增多个应用与功能</summary><p>
-						&emsp;&emsp;-Windows 12 AI Copilot(@NB-Group提供api, @tjy-gitnub魔改)<br />
-						&emsp;&emsp;-任务管理器(由 @User782Tec 提供)<br />
-						&emsp;&emsp;-安全中心(由 @NB-Group 提供)<br />
-						&emsp;&emsp;-适配文件系统(由 @NB-Group 提供)(别问我为啥现在才出，要问问@NB-Group)<br />
-						&emsp;&emsp;-窗口云母(Mica)效果(由 @tjy-gitnub 提供，在设置中启用)<br />
-						&emsp;&emsp;-文件资源管理器导航栏(由 @User782Tec 提供)<br />
-						&emsp;&emsp;-任务管理器小组件(由 @User782Tec 提供)<br />
-						&emsp;&emsp;-全新壁纸(由 @tjy-gitnub 提供)<br />
-						&emsp;&emsp;-新增新闻(来自 @for-the-zero)<br />
-						&emsp;&emsp;-修复了终端的灾难性bug<br />
-						&emsp;&emsp;-优化部分UI<br />
-						&emsp;&emsp;-细节优化和修复</p>
+					<details>
+						<summary><span>v7.0.0</span> AI助手,新增多个应用与功能</summary>
+						<p>
+							&emsp;&emsp;-Windows 12 AI Copilot(@NB-Group提供api, @tjy-gitnub魔改)<br />
+							&emsp;&emsp;-任务管理器(由 @User782Tec 提供)<br />
+							&emsp;&emsp;-安全中心(由 @NB-Group 提供)<br />
+							&emsp;&emsp;-适配文件系统(由 @NB-Group 提供)(别问我为啥现在才出，要问问@NB-Group)<br />
+							&emsp;&emsp;-窗口云母(Mica)效果(由 @tjy-gitnub 提供，在设置中启用)<br />
+							&emsp;&emsp;-文件资源管理器导航栏(由 @User782Tec 提供)<br />
+							&emsp;&emsp;-任务管理器小组件(由 @User782Tec 提供)<br />
+							&emsp;&emsp;-全新壁纸(由 @tjy-gitnub 提供)<br />
+							&emsp;&emsp;-新增新闻(来自 @for-the-zero)<br />
+							&emsp;&emsp;-修复了终端的灾难性bug<br />
+							&emsp;&emsp;-优化部分UI<br />
+							&emsp;&emsp;-细节优化和修复</p>
 					</details>
 					<details>
 						<summary><span>v6.0.0</span> 文件系统,窗口大小,天气小组件,任务栏小组件</summary>
@@ -1724,7 +2592,7 @@
 							&emsp;&emsp;-提示:在github项目页的一些<a
 								onclick="window.open('https://github.com/tjy-gitnub/win12','_blank');"
 								win12_title="https://github.com/tjy-gitnub/win12" class="jump">公告</a>
-							</p>
+						</p>
 					</details>
 					<details>
 						<summary><span>v5.1.1</span> 网页加载动画与新增应用</summary>
@@ -1917,8 +2785,9 @@
 			<img src="icon/terminal.svg" class="icon">
 		</div>
 
-		<div class="content" id="win-terminal" onmouseup="$('#win-terminal input').focus();" ontouchend="$('#win-terminal input').focus();">
-            <pre>
+		<div class="content" id="win-terminal" onmouseup="$('#win-terminal input').focus();"
+			ontouchend="$('#win-terminal input').focus();">
+			<pre>
 				Microsoft Windows [版本 12.0.39035.7324]
 				(c) Microsoft Corporation。保留所有权利。
 			</pre>
@@ -1942,8 +2811,9 @@
 			<img src="icon/python.png" class="icon">
 		</div>
 
-		<div class="content" id="win-python" onmouseup="$('#win-python input').focus();" ontouchend="$('#win-python input').focus();">
-            <pre>
+		<div class="content" id="win-python" onmouseup="$('#win-python input').focus();"
+			ontouchend="$('#win-python input').focus();">
+			<pre>
 				Python 3.10.2  [MSC v.1912 64 bit (AMD64)] :: Anaconda, Inc. on win32
 				Type "help", "copyright", "credits" or "license" for more information.
 			</pre>
@@ -1980,7 +2850,8 @@
 				</a>
 				<input type="text" onkeyup="if(event.keyCode==13&&$(this).val()!=''){apps.edge.goto($(this).val())}"
 					placeholder="在必应中搜索，或输入一个网址" class="url" spellcheck="false">
-				<input type="text" onkeyup="if(event.keyCode==13&&$(this).val()!=''){m_tab.rename('edge',$(this).val());}"
+				<input type="text"
+					onkeyup="if(event.keyCode==13&&$(this).val()!=''){m_tab.rename('edge',$(this).val());}"
 					placeholder="为标签页命名" class="rename" spellcheck="false">
 				<a class="a">
 					<i class="bi bi-info-circle" win12_title="浏览器只能访问允许嵌套的网站。由于规则限制无法获取网页标题，请右键标签页手动命名"></i>
@@ -2289,11 +3160,15 @@
 				<list class="focs">
 					<a class="processes check" onclick="apps.taskmgr.page('processes')">
 						<svg xmlns="http://www.w3.org/2000/svg" width="18px" height="18px" viewBox="3.5 5.5 29 29">
-							<path d="M 5 11 L 5 29 C 5 32 6 33 9 33 L 14 33 C 17 33 18 32 18 29 L 18 7 L 9 7 C 6 7 5 8 5 11 M 18 7 L 27 7 C 30 7 31 8 31 11 L 31 16 C 31 19 30 20 27 20 L 5 20" stroke="var(--text)" stroke-width="1.5" fill="none"/>
+							<path
+								d="M 5 11 L 5 29 C 5 32 6 33 9 33 L 14 33 C 17 33 18 32 18 29 L 18 7 L 9 7 C 6 7 5 8 5 11 M 18 7 L 27 7 C 30 7 31 8 31 11 L 31 16 C 31 19 30 20 27 20 L 5 20"
+								stroke="var(--text)" stroke-width="1.5" fill="none" />
 						</svg>
 						进程
 					</a>
-					<a class="performance" onclick="apps.taskmgr.page('performance')"><icon class="s-icon"></icon> 性能</a>
+					<a class="performance" onclick="apps.taskmgr.page('performance')">
+						<icon class="s-icon"></icon> 性能
+					</a>
 					<span class="focs"></span>
 				</list>
 			</div>
@@ -2307,9 +3182,18 @@
 						<thead>
 							<tr class="title">
 								<th>进程名称</th>
-								<th class="align-right" onclick="apps.taskmgr.changeSort(this.childNodes[0], 'cpu');"><i class="bi bi-chevron-down"></i><div class="value">11.4%</div>CPU</th>
-								<th class="align-right" onclick="apps.taskmgr.changeSort(this.childNodes[0], 'memory');"><i class="bi"></i><div class="value">11.4%</div>内存</th>
-								<th class="align-right" onclick="apps.taskmgr.changeSort(this.childNodes[0], 'disk');"><i class="bi"></i><div class="value">11.4%</div>硬盘</th>
+								<th class="align-right" onclick="apps.taskmgr.changeSort(this.childNodes[0], 'cpu');"><i
+										class="bi bi-chevron-down"></i>
+									<div class="value">11.4%</div>CPU
+								</th>
+								<th class="align-right"
+									onclick="apps.taskmgr.changeSort(this.childNodes[0], 'memory');"><i class="bi"></i>
+									<div class="value">11.4%</div>内存
+								</th>
+								<th class="align-right" onclick="apps.taskmgr.changeSort(this.childNodes[0], 'disk');">
+									<i class="bi"></i>
+									<div class="value">11.4%</div>硬盘
+								</th>
 								<th class="power">电源使用情况</th>
 							</tr>
 						</thead>
@@ -2390,7 +3274,8 @@
 							<div class="graph-cpu show">
 								<div class="tit">
 									<div class="left-name">CPU</div>
-									<div class="right-message">The Wandering Earth (R) NB (R) Quantum Chip 550W @ 8192</div>
+									<div class="right-message">The Wandering Earth (R) NB (R) Quantum Chip 550W @ 8192
+									</div>
 								</div>
 								<div class="graph-msg top">
 									<div class="left">% 利用率</div>
@@ -2406,24 +3291,66 @@
 								</div>
 								<div class="information">
 									<div class="left">
-										<div><div class="top">利用率</div><div class="value">11.4%</div></div>
-										<div><div class="top">速度</div><div class="value">1024.53 GHz</div></div>
-										<div><div class="top">进程</div><div class="value">1145</div></div>
-										<div><div class="top">线程</div><div class="value">114514</div></div>
-										<div><div class="top">句柄</div><div class="value">114514191918</div></div>
-										<div><div class="top">正常运行时间</div><div class="value">0:11:45:14</div></div>
+										<div>
+											<div class="top">利用率</div>
+											<div class="value">11.4%</div>
+										</div>
+										<div>
+											<div class="top">速度</div>
+											<div class="value">1024.53 GHz</div>
+										</div>
+										<div>
+											<div class="top">进程</div>
+											<div class="value">1145</div>
+										</div>
+										<div>
+											<div class="top">线程</div>
+											<div class="value">114514</div>
+										</div>
+										<div>
+											<div class="top">句柄</div>
+											<div class="value">114514191918</div>
+										</div>
+										<div>
+											<div class="top">正常运行时间</div>
+											<div class="value">0:11:45:14</div>
+										</div>
 									</div>
 									<div class="right">
 										<table>
 											<tbody>
-												<tr><td>基准速度: </td><td>10.0 GHz</td></tr>
-												<tr><td>插槽: </td><td>1</td></tr>
-												<tr><td>内核: </td><td>32</td></tr>
-												<tr><td>逻辑处理器: </td><td>32</td></tr>
-												<tr><td>虚拟化: </td><td>已启用</td></tr>
-												<tr><td>L1缓存: </td><td>512 MB</td></tr>
-												<tr><td>L2缓存: </td><td>2.1 GB</td></tr>
-												<tr><td>L3缓存: </td><td>5.5 GB</td></tr>
+												<tr>
+													<td>基准速度: </td>
+													<td>10.0 GHz</td>
+												</tr>
+												<tr>
+													<td>插槽: </td>
+													<td>1</td>
+												</tr>
+												<tr>
+													<td>内核: </td>
+													<td>32</td>
+												</tr>
+												<tr>
+													<td>逻辑处理器: </td>
+													<td>32</td>
+												</tr>
+												<tr>
+													<td>虚拟化: </td>
+													<td>已启用</td>
+												</tr>
+												<tr>
+													<td>L1缓存: </td>
+													<td>512 MB</td>
+												</tr>
+												<tr>
+													<td>L2缓存: </td>
+													<td>2.1 GB</td>
+												</tr>
+												<tr>
+													<td>L3缓存: </td>
+													<td>5.5 GB</td>
+												</tr>
 											</tbody>
 										</table>
 									</div>
@@ -2449,25 +3376,56 @@
 								<div class="graph-msg top">
 									<div class="left">内存组合</div>
 								</div>
-								<div class="graph memory2 minor" style="margin-bottom: 10px; border: 1px #660099 solid; height: 35px !important">
+								<div class="graph memory2 minor"
+									style="margin-bottom: 10px; border: 1px #660099 solid; height: 35px !important">
 									<canvas class="chart2" width="1280" height="35"></canvas>
 								</div>
 								<div class="information">
 									<div class="left">
-										<div><div class="top">使用中(已压缩)</div><div class="value">11.4 GB</div></div>
-										<div><div class="top">可用</div><div class="value">88.6 GB</div></div>
-										<div><div class="top">已提交</div><div class="value">12 / 100 GB</div></div>
-										<div><div class="top">已缓存</div><div class="value">5.5 GB</div></div>
-										<div><div class="top">分页缓冲池</div><div class="value">1 GB</div></div>
-										<div><div class="top">非分页缓冲池</div><div class="value">365 MB</div></div>
+										<div>
+											<div class="top">使用中(已压缩)</div>
+											<div class="value">11.4 GB</div>
+										</div>
+										<div>
+											<div class="top">可用</div>
+											<div class="value">88.6 GB</div>
+										</div>
+										<div>
+											<div class="top">已提交</div>
+											<div class="value">12 / 100 GB</div>
+										</div>
+										<div>
+											<div class="top">已缓存</div>
+											<div class="value">5.5 GB</div>
+										</div>
+										<div>
+											<div class="top">分页缓冲池</div>
+											<div class="value">1 GB</div>
+										</div>
+										<div>
+											<div class="top">非分页缓冲池</div>
+											<div class="value">365 MB</div>
+										</div>
 									</div>
 									<div class="right">
 										<table>
 											<tbody>
-												<tr><td>速度: </td><td>4514MHz</td></tr>
-												<tr><td>已使用插槽: </td><td>2 / 2</td></tr>
-												<tr><td>外形规格: </td><td>Row of chips</td></tr>
-												<tr><td>为硬件保留的内存：</td><td>200MB</td></tr>
+												<tr>
+													<td>速度: </td>
+													<td>4514MHz</td>
+												</tr>
+												<tr>
+													<td>已使用插槽: </td>
+													<td>2 / 2</td>
+												</tr>
+												<tr>
+													<td>外形规格: </td>
+													<td>Row of chips</td>
+												</tr>
+												<tr>
+													<td>为硬件保留的内存：</td>
+													<td>200MB</td>
+												</tr>
 											</tbody>
 										</table>
 									</div>
@@ -2494,25 +3452,53 @@
 									<div class="left">磁盘传输速率</div>
 									<div class="right">100 MB/秒</div>
 								</div>
-								<div class="graph disk2 minor" style="margin-bottom: 10px; height: 70px !important; min-height: 70px !important;">
+								<div class="graph disk2 minor"
+									style="margin-bottom: 10px; height: 70px !important; min-height: 70px !important;">
 									<canvas class="chart2" width="1920" height="280"></canvas>
 									<canvas class="bg2" width="1920" height="280"></canvas>
 								</div>
 								<div class="information">
 									<div class="left">
-										<div><div class="top">活动时间</div><div class="value">1.14%</div></div>
-										<div><div class="top">平均响应时间</div><div class="value">0.014 毫秒</div></div>
-										<div style="border-left: 2px #008000 solid; padding-left: 10px;"><div class="top">读取速度</div><div class="value">14 KB/秒</div></div>
-										<div style="border-left: 2px #008000 dotted; padding-left: 10px;"><div class="top">写入速度</div><div class="value">114 KB/秒</div></div>
+										<div>
+											<div class="top">活动时间</div>
+											<div class="value">1.14%</div>
+										</div>
+										<div>
+											<div class="top">平均响应时间</div>
+											<div class="value">0.014 毫秒</div>
+										</div>
+										<div style="border-left: 2px #008000 solid; padding-left: 10px;">
+											<div class="top">读取速度</div>
+											<div class="value">14 KB/秒</div>
+										</div>
+										<div style="border-left: 2px #008000 dotted; padding-left: 10px;">
+											<div class="top">写入速度</div>
+											<div class="value">114 KB/秒</div>
+										</div>
 									</div>
 									<div class="right">
 										<table>
 											<tbody>
-												<tr><td>容量: </td><td>359 GB</td></tr>
-												<tr><td>已格式化: </td><td>359 GB</td></tr>
-												<tr><td>系统磁盘: </td><td>是</td></tr>
-												<tr><td>页面文件: </td><td>是</td></tr>
-												<tr><td>类型: </td><td>SSD</td></tr>
+												<tr>
+													<td>容量: </td>
+													<td>359 GB</td>
+												</tr>
+												<tr>
+													<td>已格式化: </td>
+													<td>359 GB</td>
+												</tr>
+												<tr>
+													<td>系统磁盘: </td>
+													<td>是</td>
+												</tr>
+												<tr>
+													<td>页面文件: </td>
+													<td>是</td>
+												</tr>
+												<tr>
+													<td>类型: </td>
+													<td>SSD</td>
+												</tr>
 											</tbody>
 										</table>
 									</div>
@@ -2537,8 +3523,14 @@
 								</div>
 								<div class="information">
 									<div class="left">
-										<div><div class="top">发送</div><div class="value">114 Mbps</div></div>
-										<div><div class="top">接收</div><div class="value">114 Mbps</div></div>
+										<div>
+											<div class="top">发送</div>
+											<div class="value">114 Mbps</div>
+										</div>
+										<div>
+											<div class="top">接收</div>
+											<div class="value">114 Mbps</div>
+										</div>
 									</div>
 									<div class="right">
 										<table>
@@ -2566,8 +3558,11 @@
 												<tr>
 													<td>信号强度: </td>
 													<td>
-														<svg xmlns="http://www.w3.org/2000/svg" viewBox="4.4 4.4 26.2 31.2" width="1.45em" height="1.4em">
-															<path d="M 5 25 L 5 35 L 10 35 L 10 25 L 5 25 M 10 20 L 10 35 L 15 35 L 15 20 L 10 20 M 15 15 L 20 15 L 20 35 L 15 35 L 15 15 M 20 10 L 25 10 L 25 35 L 20 35 L 20 10 M 25 5 L 25 35 L 30 35 L 30 5 L 25 5" stroke="#8e5829" stroke-width="0.6" fill="#8e582988"/>
+														<svg xmlns="http://www.w3.org/2000/svg"
+															viewBox="4.4 4.4 26.2 31.2" width="1.45em" height="1.4em">
+															<path
+																d="M 5 25 L 5 35 L 10 35 L 10 25 L 5 25 M 10 20 L 10 35 L 15 35 L 15 20 L 10 20 M 15 15 L 20 15 L 20 35 L 15 35 L 15 15 M 20 10 L 25 10 L 25 35 L 20 35 L 20 10 M 25 5 L 25 35 L 30 35 L 30 5 L 25 5"
+																stroke="#8e5829" stroke-width="0.6" fill="#8e582988" />
 														</svg>
 													</td>
 												</tr>
@@ -2616,7 +3611,9 @@
 									<div class="left">专用 GPU 内存利用率</div>
 									<div class="right">16 GB</div>
 								</div>
-								<div class="graph gpu2-1 minor" style="height: 70px !important; min-height: 70px !important;" win12_title="专用 GPU 内存利用率">
+								<div class="graph gpu2-1 minor"
+									style="height: 70px !important; min-height: 70px !important;"
+									win12_title="专用 GPU 内存利用率">
 									<canvas class="chart2" width="1920" height="280"></canvas>
 									<canvas class="bg2" width="1920" height="280"></canvas>
 								</div>
@@ -2624,16 +3621,30 @@
 									<div class="left">共享 GPU 内存利用率</div>
 									<div class="right">32 GB</div>
 								</div>
-								<div class="graph gpu2-2 minor" style="height: 70px !important; min-height: 70px !important; margin-bottom: 10px" win12_title="共享 GPU 内存利用率">
+								<div class="graph gpu2-2 minor"
+									style="height: 70px !important; min-height: 70px !important; margin-bottom: 10px"
+									win12_title="共享 GPU 内存利用率">
 									<canvas class="chart2" width="1920" height="280"></canvas>
 									<canvas class="bg2" width="1920" height="280"></canvas>
 								</div>
 								<div class="information">
 									<div class="left">
-										<div><div class="top">利用率</div><div class="value">1.1%</div></div>
-										<div><div class="top">专用 GPU 内存</div><div class="value">0.1 GB / 2 GB</div></div>
-										<div><div class="top">共享 GPU 内存</div><div class="value">1.1 GB / 16 GB</div></div>
-										<div><div class="top">GPU 内存</div><div class="value">1.2 / 18 GB</div></div>
+										<div>
+											<div class="top">利用率</div>
+											<div class="value">1.1%</div>
+										</div>
+										<div>
+											<div class="top">专用 GPU 内存</div>
+											<div class="value">0.1 GB / 2 GB</div>
+										</div>
+										<div>
+											<div class="top">共享 GPU 内存</div>
+											<div class="value">1.1 GB / 16 GB</div>
+										</div>
+										<div>
+											<div class="top">GPU 内存</div>
+											<div class="value">1.2 / 18 GB</div>
+										</div>
 									</div>
 									<div class="right">
 										<table>
@@ -2670,10 +3681,12 @@
 	<script src="module/tab.js"></script>
 	<script src="https://fastly.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js" async></script>
 	<!-- <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
-	<script defer src="https://pyscript.net/latest/pyscript.js"></script> -->         <!-- PyScript, 已弃用 -->
+	<script defer src="https://pyscript.net/latest/pyscript.js"></script> --> <!-- PyScript, 已弃用 -->
 	<script src="https://cdn.staticfile.org/ace/1.23.0/ace.min.js"></script>
 	<script src="https://cdn.staticfile.org/ace/1.23.0/ext-language_tools.min.js"></script>
 	<script src="https://cdn.staticfile.org/ace/1.23.0/ext-error_marker.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/10.4.2/math.min.js"></script>
+
 </body>
 
 </html>


### PR DESCRIPTION
### 修复计算器中的浮点数精度问题

此pull request解决了计算器中观察到的浮点数精度问题。

#### 更改内容
- **引入库**：使用`math.js`库来评估数学表达式
- **替换运算**：不再使用`eval()`,他可以执行所有js，这不安全，用`math.evaluate`方法替换了直接的数学运算，以确保得到准确的结果
- **结果格式化**：将结果格式化为14位精度，避免常见的浮点数不准确性

#### 更改原因
由于浮点数的不准确性，例如`0.1 + 0.2`不等于`0.3`的。通过使用`math.js`库，确保了计算器提供期望的结果
