### PR TITLE
 添加设备内的“蓝牙与设备”

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -873,7 +873,7 @@
 		</div>
 	</div>
 	<div id="desktop">
-		<div class="b" ondblclick="openapp('explorer');" ontouchstart="openapp('explorer');" win12_title="显示连接到此计算机的驱动器和硬件。" oncontextmenu="return showcm(event,'desktop.icon',['explorer',-1]);" appname="explorer">
+		<div ondblclick="openapp('explorer');" ontouchstart="openapp('explorer');" win12_title="显示连接到此计算机的驱动器和硬件。" oncontextmenu="return showcm(event,'desktop.icon',['explorer',-1]);" appname="explorer">
 			<img src="apps/icons/explorer/thispc.svg">
 			<p>此电脑</p>
 		</div>

--- a/desktop.js
+++ b/desktop.js
@@ -641,7 +641,7 @@ var shutdown_task = []; //关机任务，储存在这个数组里
 // 为什么要数组？
 // 运行的指令
 function runcmd(cmd) {
-    if (cmd.slice(0, 3) == "cmd") {
+    if (cmd == 'cmd' || cmd == 'cmd.exe') {
         run_cmd = cmd;
         openapp('terminal');
         return true;


### PR DESCRIPTION
为什么会被b5f5dd7的pull覆盖？