### PR TITLE
为 Service Worker 增加拦截请求时的筛选规则

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -5,6 +5,8 @@ let dymanic = [
   'assets.msn.cn'
 ]
 this.addEventListener('fetch', function (event) {
+  if (!/^https?:$/.test(new URL(event.request.url).protocol)) return
+
   event.respondWith(
     caches.match(event.request).then(res => {
       let fl = false;
@@ -21,7 +23,6 @@ this.addEventListener('fetch', function (event) {
       return res ||
         fetch(event.request)
           .then(responese => {
-            // console.log(event.request);
             const responeseClone = responese.clone();
             caches.open('def').then(cache => {
               console.log('下载数据', responeseClone.url);


### PR DESCRIPTION
为 Service Worker 增加拦截请求时的筛选规则，主要是仅拦截 HTTP 及 HTTPS 协议的请求，其余类型协议的请求不做额外处理

原因：

CacheStorage 只允许存储 HTTP 或 HTTPS 协议的请求-响应数据，其余类型的协议在试图存储时直接抛出 TypeError 异常，参见 https://w3c.github.io/ServiceWorker/#cache-objects

换言之，非 HTTP 及 HTTPS 协议的请求只可能走间接请求的方式，因此这里对于非 HTTP 及 HTTPS 协议的请求直接退出当前事件监听器使用浏览器默认的请求策略，某种意义上也避免了不必要的代码执行；HTTP 及 HTTPS 协议的请求仍按原有逻辑执行

可以避免的问题示例如下
![image](https://github.com/tjy-gitnub/win12/assets/95597335/279a877f-2dd8-415c-a71a-9c9af3b048b2)

---

同时移除了一个多余的 log 代码
