### PR TITLE
统一化CDN并避免供应链攻击

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -2976,11 +2976,11 @@ toggletheme() 切换主题
 
 	<script defer src="scripts/setting_getTime.js"></script><!-- 设置页面获取时间逻辑 @Junchen Yi 2023-9-17-->
 	<script defer src="scripts/news.js"></script>
-	<script defer src="https://fastly.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js" async></script>
-	<script defer src="https://cdn.staticfile.org/ace/1.23.0/ace.min.js"></script>
-	<script defer src="https://cdn.staticfile.org/ace/1.23.0/ext-language_tools.min.js"></script>
-	<script defer src="https://cdn.staticfile.org/ace/1.23.0/ext-error_marker.min.js"></script>
-	<script defer src='https://cdn.staticfile.org/big.js/6.2.1/big.min.js'></script>
+	<script defer src="https://unpkg.com/pyodide@0.23.4/pyodide.js" async></script>
+	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.0/ace.min.js"></script>
+	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.0/ext-language_tools.min.js"></script>
+	<script defer src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.0/ext-error_marker.min.js"></script>
+	<script defer src='https://cdnjs.cloudflare.com/ajax/libs/big.js/6.2.1/big.min.js'></script>
 	<script defer src="./scripts/calculator_kernel.js"></script>
 	<script defer src='https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js'></script>
 


### PR DESCRIPTION
Issue: #624 

其中 `pyodide` 如果用 cloudflare cdnjs 会导致找不到 `python-stdlib.zip` 而报错，故改用 UNPKG