### PR TITLE
更新README.md中的API服务商官网

### DIFF
--- a/scripts/AI Copilot service/README.md
+++ b/scripts/AI Copilot service/README.md
@@ -3,7 +3,7 @@
 
 原文档由github@NB-Group提供，可查看其在互联网档案馆的[存档](https://web.archive.org/web/20251115175835/https://github.com/tjy-gitnub/win12/blob/main/scripts/AI%20Copilot%20service/README.md)
 ## 介绍
-AI Copilot 是一个基于 AI 的文本生成工具，可以生成文本.本 AI 由云智API（[api.jkyai.top](api.jkyai.top)）提供支持，其接受来自前端页面的请求，并返回生成文本。
+AI Copilot 是一个基于 AI 的文本生成工具，可以生成文本.本 AI 由云智API（[yunzhiapi.cn](https://www.yunzhiapi.cn)）提供支持，其接受来自前端页面的请求，并返回生成文本。
 
 云智API提供的公益接口对于单日请求有次数限制，每个站点单日请求不能超过1500次，但为本项目用户提供服务这个次数已完全够用。
 


### PR DESCRIPTION
请注意，API服务商官网已变更为yunzhiapi.cn，请知悉。