### PR TITLE
Feat: Cascade new windows to prevent overlap

### DIFF
--- a/module/window.js
+++ b/module/window.js
@@ -7,7 +7,7 @@ function showwin(name) {
     setTimeout(() => { $('.window.' + name).addClass('show'); }, 0);
     setTimeout(() => { $('.window.' + name).addClass('notrans'); }, 200);
     if (name != 'run') {
-        $('.window.' + name).attr('style', 'top: 10%;left: 15%;');
+        $('.window.' + name).attr('style', 'top: calc(10% + ' + (wo.length % 10 * 25) + 'px); left: calc(15% + ' + (wo.length % 10 * 25) + 'px);');
     }
     $('#taskbar>.' + wo[0]).removeClass('foc');
     $('.window.' + wo[0]).removeClass('foc');


### PR DESCRIPTION
## Summary

This addresses an issue where multiple windows open in the exact same position, completely overlapping and hiding each other. A cascading effect has been implemented for new windows. Each new window is now opened with a slight offset, making it clear that multiple windows are open and improving the user experience.

## Changes

- **module/window.js**: In the `showwin` function, calculate an offset for new windows based on the number of currently open windows. This creates a cascading effect, preventing new windows from completely overlapping by positioning them slightly offset from each other.

## Related Issue

Closes #763

