### PR TITLE
feat(shortcut): 新增 Alt + E / Alt + I 快捷键以提升桌面操作体验

### DIFF
--- a/desktop.js
+++ b/desktop.js
@@ -2543,8 +2543,8 @@ function setupGlobalKey() {
             return;
         }
 
-        //按下徽标键 + E，打开文件资源管理器（此电脑）
-        if (event.metaKey && !event.ctrlKey && !event.altKey && (event.key || '').toLowerCase() == 'e') {
+        //按下徽标键 + E / 徽标键 + Ctrl + E，打开文件资源管理器（此电脑）
+        if (event.metaKey && !event.altKey && (event.key || '').toLowerCase() == 'e') {
             event.preventDefault();
             if (!event.repeat) {
                 openapp('explorer');
@@ -2553,8 +2553,8 @@ function setupGlobalKey() {
             return;
         }
 
-        //按下徽标键 + I，打开设置
-        if (event.metaKey && !event.ctrlKey && !event.altKey && (event.key || '').toLowerCase() == 'i') {
+        //按下徽标键 + I / 徽标键 + Ctrl + I，打开设置
+        if (event.metaKey && !event.altKey && (event.key || '').toLowerCase() == 'i') {
             event.preventDefault();
             if (!event.repeat) {
                 openapp('setting');

--- a/desktop.js
+++ b/desktop.js
@@ -2553,6 +2553,15 @@ function setupGlobalKey() {
             return;
         }
 
+        //按下徽标键 + I，打开设置
+        if (event.metaKey && !event.ctrlKey && !event.altKey && (event.key || '').toLowerCase() == 'i') {
+            event.preventDefault();
+            if (!event.repeat) {
+                openapp('setting');
+            }
+            return;
+        }
+
         //按下徽标键
         if (event.metaKey && event.ctrlKey) {
             //打开或关闭开始菜单

--- a/desktop.js
+++ b/desktop.js
@@ -2543,6 +2543,16 @@ function setupGlobalKey() {
             return;
         }
 
+        //按下徽标键 + E，打开文件资源管理器（此电脑）
+        if (event.metaKey && !event.ctrlKey && !event.altKey && (event.key || '').toLowerCase() == 'e') {
+            event.preventDefault();
+            if (!event.repeat) {
+                openapp('explorer');
+                apps.explorer.reset();
+            }
+            return;
+        }
+
         //按下徽标键
         if (event.metaKey && event.ctrlKey) {
             //打开或关闭开始菜单

--- a/desktop.js
+++ b/desktop.js
@@ -2543,8 +2543,8 @@ function setupGlobalKey() {
             return;
         }
 
-        //按下徽标键 + E / 徽标键 + Ctrl + E，打开文件资源管理器（此电脑）
-        if (event.metaKey && !event.altKey && (event.key || '').toLowerCase() == 'e') {
+        //按下徽标键 + E / 徽标键 + Ctrl + E / Alt + E，打开文件资源管理器（此电脑）
+        if (((event.metaKey && !event.altKey) || (!event.metaKey && event.altKey)) && (event.key || '').toLowerCase() == 'e') {
             event.preventDefault();
             if (!event.repeat) {
                 openapp('explorer');
@@ -2553,8 +2553,8 @@ function setupGlobalKey() {
             return;
         }
 
-        //按下徽标键 + I / 徽标键 + Ctrl + I，打开设置
-        if (event.metaKey && !event.altKey && (event.key || '').toLowerCase() == 'i') {
+        //按下徽标键 + I / 徽标键 + Ctrl + I / Alt + I，打开设置
+        if (((event.metaKey && !event.altKey) || (!event.metaKey && event.altKey)) && (event.key || '').toLowerCase() == 'i') {
             event.preventDefault();
             if (!event.repeat) {
                 openapp('setting');

--- a/desktop.js
+++ b/desktop.js
@@ -2543,23 +2543,25 @@ function setupGlobalKey() {
             return;
         }
 
-        //按下徽标键 + E / 徽标键 + Ctrl + E / Alt + E，打开文件资源管理器（此电脑）
-        if (((event.metaKey && !event.altKey) || (!event.metaKey && event.altKey)) && (event.key || '').toLowerCase() == 'e') {
-            event.preventDefault();
-            if (!event.repeat) {
-                openapp('explorer');
-                apps.explorer.reset();
+        // 激活键：Meta / Meta + Ctrl / Alt
+        if ((event.metaKey && !event.altKey) || (!event.metaKey && event.altKey)) {
+        //按下激活键 + E，打开文件资源管理器（此电脑）
+            if ((event.key || '').toLowerCase() == 'e') {
+                event.preventDefault();
+                if (!event.repeat) {
+                    openapp('explorer');
+                    apps.explorer.reset();
+                }
+                return;
             }
-            return;
-        }
-
-        //按下徽标键 + I / 徽标键 + Ctrl + I / Alt + I，打开设置
-        if (((event.metaKey && !event.altKey) || (!event.metaKey && event.altKey)) && (event.key || '').toLowerCase() == 'i') {
-            event.preventDefault();
-            if (!event.repeat) {
-                openapp('setting');
+            //按下激活键 + I，打开设置
+            if ((event.key || '').toLowerCase() == 'i') {
+                event.preventDefault();
+                if (!event.repeat) {
+                    openapp('setting');
+                }
+                return;
             }
-            return;
         }
 
         //按下徽标键


### PR DESCRIPTION
## 变更内容
>Super键是指Windows（徽标键 / Meta 键）

新增基于 Super（徽标键 / Meta 键） 的快捷键支持：

`Super + E`：打开文件资源管理器（此电脑）
`Super + I`：打开设置
##  实现细节
监听` event.metaKey `作为 `Super `键（兼容 Linux / macOS）
限制组合键：
不包含 Ctrl / Alt，避免冲突
使用 `event.preventDefault()` 阻止默认行为
通过 `event.repeat `防止长按触发多次
## 设计目的
对齐 Windows 常用快捷键习惯（Win + E / Win + I）
提升 win12 的桌面化操作体验
提供更直观的应用打开方式
##  兼容性说明
在部分系统中：
某些 Super 组合键可能被系统占用，浏览器无法捕获
在 Linux 环境下通常可正常使用