### PR TITLE
二次修复Microsoft StoreApp内图标

### DIFF
--- a/apps/style/msstore.css
+++ b/apps/style/msstore.css
@@ -149,7 +149,7 @@
 
                                 &.card1>.left {
                                     background-color: #1f1f1f;
-                                    background-image: url("https://code.visualstudio.com/assets/favicon.ico");
+                                    background-image: url("../../icon/vscode.png");
                                     background-size: 58px 58px;
                                 }
 

--- a/apps/style/msstore.css
+++ b/apps/style/msstore.css
@@ -154,7 +154,7 @@
                                 }
 
                                 &.card2>.left {
-                                    background-image: url("https://ys.mihoyo.com/main/favicon.ico");
+                                    background-image: url("https://bkimg.cdn.bcebos.com/pic/024f78f0f736afc37206d596bd19ebc4b745123e?x-bce-process=image/format,f_auto/quality,Q_70/resize,m_lfit,limit_1,w_536");
                                 }
 
                                 &.card3>.left {


### PR DESCRIPTION
## 我做的改动
我将Vscode的图片改回了项目内置的vscode图标，因为我发现他已经被内联很多了。此外在此使用外链会导致vscode图标无法正常显示。
我更换了原神APP的图标外链，使其变得更清晰。
## 图片
修改前:
<img width="2606" height="731" alt="image" src="https://github.com/user-attachments/assets/c9f10f19-7ac3-4470-accb-fe9459aaa5ce" />
修改后
<img width="2845" height="596" alt="image" src="https://github.com/user-attachments/assets/fe6085e5-8d91-4bee-9a73-d44284096035" />
## 相关历史PR
#802 