### PR TITLE
fix: Edge搜索栏输入空格时不再跳转Bing搜索

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -2200,7 +2200,7 @@ toggletheme() 切换主题
 				<a class="a" onclick="apps.edge.reload()">
 					<i class="bi bi-arrow-clockwise"></i>
 				</a>
-				<input type="text" onpointerdown="this.select();" onkeyup="if(event.keyCode==13&&$(this).val()!=''){apps.edge.goto($(this).val())}"
+				<input type="text" onpointerdown="this.select();" onkeyup="if(event.keyCode==13&&$(this).val().trim()!=''){apps.edge.goto($(this).val())}"
 					placeholder="在必应中搜索，或输入一个网址" class="url" spellcheck="false" id="edge-path" data-i18n-attr="placeholder" data-i18n-key="edge.schbing">
 				<input type="text" onkeyup="if(event.keyCode==13&&$(this).val()!=''){m_tab.rename('edge',$(this).val());}"
 					placeholder="为标签页命名" class="rename" spellcheck="false"  data-i18n-attr="placeholder" data-i18n-key="edge.rename">

--- a/module/apps.js
+++ b/module/apps.js
@@ -2353,12 +2353,12 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             $('#win-edge>.tool>input.url').focus();
             $('#win-edge>iframe')[apps.edge.tabs.length - 1].onload = function () {
                 this.contentDocument.querySelector('input').onkeyup = function (e) {
-                    if (e.keyCode == 13 && $(this).val() != '') {
+                    if (e.keyCode == 13 && $(this).val().trim() != '') {
                         apps.edge.goto($(this).val());
                     }
                 };
                 this.contentDocument.querySelector('svg').onclick = () => {
-                    if ($(this.contentDocument.querySelector('input')).val() != '') {
+                    if ($(this.contentDocument.querySelector('input')).val().trim() != '') {
                         apps.edge.goto($(this.contentDocument.querySelector('input')).val());
                     }
                 };
@@ -2455,6 +2455,8 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             }
         },
         goto: (u, clear = true) => {
+            u = u.trim();
+            if (!u) return;
             if (wifiStatus == false) {
                 m_tab.rename('edge', u);
                 $('#win-edge>iframe.show').attr('src', '.data/disconnected' + (isDark ? '_dark' : '') + '.html');


### PR DESCRIPTION
## 修复内容

修复 #747

Edge 搜索栏仅输入空格时会跳转到 Bing 搜索页面，实际上应该忽略纯空白输入。

## 改动

- `goto` 函数入口对输入做 `trim()` 处理，空白内容直接 return
- 地址栏和新标签页搜索框的触发条件中增加 `.trim()` 判断

## 测试

在 Edge 地址栏和新标签页搜索框中输入纯空格后按回车，不再跳转搜索页面。输入正常内容仍可正常搜索和导航。