### PR TITLE
fix: 修复窗口最大化后最小化导致任务栏消失的问题

### DIFF
--- a/module/window.js
+++ b/module/window.js
@@ -142,6 +142,17 @@ function minwin(name) {
         $('.window.' + name).addClass('min');
         $('.window.' + name).removeClass('notrans');
         setTimeout(() => { $('.window.' + name).removeClass('show-begin'); }, 200);
+        if (!$('#start-menu.show')[0] && !$('#search-win.show')[0] && !$('#widgets.show')[0] && !$('#control.show')[0] && !$('#datebox.show')[0]) {
+            if ($('.window.max:not(.left):not(.right)')[0]) {
+                $('#dock-box').addClass('hide');
+            }
+            else {
+                $('#dock-box').removeClass('hide');
+            }
+        }
+        else {
+            $('#dock-box').removeClass('hide');
+        }
     }
 }
 


### PR DESCRIPTION
## 修复内容

修复 #669

窗口最大化后再最小化，底部任务栏（dock-box）会消失不显示。

## 原因

最小化窗口时移除了 `max` class，但没有重新计算 dock-box 的可见性。其他操作（showwin、hidewin、maxwin）都有这个逻辑，唯独 minwin 的最小化分支遗漏了。

## 改动

在 `minwin` 最小化分支末尾补充 dock-box 可见性更新逻辑，与其他窗口操作保持一致。

## 测试

打开任意应用 → 最大化 → 最小化，任务栏正常显示。