### PR TITLE
feat: 横屏提示增加关闭按钮，允许用户继续使用竖屏

### DIFF
--- a/desktop.css
+++ b/desktop.css
@@ -2815,6 +2815,22 @@ body>.container>.image-container>.svg {
     }
 }
 
+.orientation-close-btn {
+    margin-top: 10px;
+    padding: 8px 24px;
+    border: 1px solid var(--text);
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background .2s;
+}
+
+.orientation-close-btn:hover {
+    background: rgba(128, 128, 128, 0.2);
+}
+
 #taskbar-preview {
     position: fixed;
     bottom: 60px;

--- a/desktop.html
+++ b/desktop.html
@@ -182,6 +182,7 @@ toggletheme() 切换主题
             <img src="icon/ls.svg" alt="旋转图标" class="svg rotating">
         </div>
         <div data-i18n="cover-hp">横屏以获得最佳体验</div>
+        <button class="orientation-close-btn" onclick="dismissOrientation();" data-i18n="cover-hp-close">继续使用竖屏</button>
     </div>
 	<div id="loginback">
 		<div class="user"></div>

--- a/desktop.js
+++ b/desktop.js
@@ -2558,14 +2558,22 @@ function isMobileDevice() {
     return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+let orientationDismissed = false;
+
 function checkOrientation() {
+    if (orientationDismissed) return;
     const container = document.getElementById('orientation-warning');
     const isPortrait = window.matchMedia("(orientation: portrait)").matches;
     if (isMobileDevice() && isPortrait) {
-        container.style.display = "flex"; // 显示提示
+        container.style.display = "flex";
     } else {
-        container.style.display = "none"; // 隐藏提示
+        container.style.display = "none";
     }
+}
+
+function dismissOrientation() {
+    orientationDismissed = true;
+    document.getElementById('orientation-warning').style.display = 'none';
 }
 
 // 监听屏幕方向变化


### PR DESCRIPTION
## 改动内容

修复 #572

移动端竖屏时的横屏提示无法关闭，对有竖屏需求的用户不友好。

## 改动

- 横屏提示区域增加「继续使用竖屏」按钮
- 用户点击关闭后，当前会话内不再重复弹出
- 按钮支持 i18n（data-i18n=`cover-hp-close`）
- 样式适配深色/浅色主题

## 测试

移动端竖屏访问 → 出现横屏提示 → 点击「继续使用竖屏」 → 提示关闭 → 旋转屏幕再转回竖屏不再弹出。