### PR TITLE
ci:添加工作流以在主分支推送时调度桌面仓库

### DIFF
--- a/.github/workflows/notify_desktop_repo.yml
+++ b/.github/workflows/notify_desktop_repo.yml
@@ -1,0 +1,28 @@
+name: Notify desktop repo
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify desktop repo
+        run: |
+          curl -L -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.DESKTOP_REPO_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/win12-online/win12-desktop/dispatches \
+            -d '{
+              "event_type":"submodule-updated",
+              "client_payload":{
+                "path":"tauri/src",
+                "sha":"${{ github.sha }}",
+                "repo":"${{ github.repository }}",
+                "branch":"${{ github.ref_name }}"
+              }
+            }'


### PR DESCRIPTION
会在本仓库发生变化时通知B仓库更新子模块
## 需要的额外操作
在本仓库中新增名为`DISPATCH_TOKEN`的机密
需要读写这两个仓库的全新