### PR TITLE
fix(taskbar): 使用实际任务项数量同步布局 fix:#833

### DIFF
--- a/desktop.js
+++ b/desktop.js
@@ -1887,6 +1887,12 @@ function geticon(name) {
     else return name + '.svg';
 }
 
+function syncTaskbarLayout() {
+    const count = $('#taskbar>a').length;
+    $('#taskbar').attr('count', count);
+    $('#taskbar').css('display', count == 0 ? 'none' : 'flex');
+    $('#taskbar').css('width', 4 + count * (34 + 4));
+}
 
 function openapp(name) {
     if (taskmgrTasks.findIndex(elt => elt.link == name) > -1 && apps.taskmgr.tasks.findIndex(elt => elt.link == name) == -1) {
@@ -1901,14 +1907,11 @@ function openapp(name) {
     }
     $('.window.' + name).addClass('load');
     showwin(name);
-    $('#taskbar').attr('count', Number($('#taskbar').attr('count')) + 1);
     $('#taskbar').append(`<a class="${name}" onclick="taskbarclick('${name}\')" win12_title="${$(`.window.${name}>.titbar>p`).text()}" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" oncontextmenu="return showcm(event, 'taskbar', '${name}')"><img src="icon/${icon[name] || (name + '.svg')}"></a>`);
-    if ($('#taskbar').attr('count') == '1') {
-        $('#taskbar').css('display', 'flex');
-    }
+    syncTaskbarLayout();
     $('#taskbar>.' + name).addClass('foc');
     setTimeout(() => {
-        $('#taskbar').css('width', 4 + $('#taskbar').attr('count') * (34 + 4));
+        syncTaskbarLayout();
     }, 0);
     let tmp = name.replace(/\-(\w)/g, function (all, letter) {
         return letter.toUpperCase();

--- a/module/window.js
+++ b/module/window.js
@@ -36,13 +36,10 @@ function hidewin(name, arg = 'window') {
       closeVideo()
     }
     if (arg == 'window') {
-        $('#taskbar').attr('count', Number($('#taskbar').attr('count')) - 1);
         $('#taskbar>.' + name).remove();
-        $('#taskbar').css('width', 4 + $('#taskbar').attr('count') * (34 + 4));
+        syncTaskbarLayout();
         setTimeout(() => {
-            if ($('#taskbar').attr('count') == '0') {
-                $('#taskbar').css('display', 'none');
-            }
+            syncTaskbarLayout();
         }, 80);
     }
     setTimeout(() => {


### PR DESCRIPTION
添加一个共享的 syncTaskbarLayout 辅助方法，用于根据当前 DOM 项计算任务栏的数量、显示状态和宽度。

在打开和关闭窗口时使用此辅助方法，以避免使用过时的计数值，并保持任务栏大小和可见性的一致性。

fix:#833