### PR TITLE
Add Now Playing widget

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -605,6 +605,66 @@ toggletheme() 切换主题
 							</div>
 						</div>
 					</div>
+<div class="nowplaying">
+<div class="wg nowplaying template">
+<div class="titbar">
+<a win12_title="更多" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" class="a more notip" onclick="$(this).siblings('.menu').toggleClass('show')">
+<i class="bi bi-three-dots"></i>
+</a>
+<div class="menu">
+<a win12_title="打开应用" class="a img openapp" onclick="$(this).parent().removeClass('show');hide_widgets();shownotice('NowPlaying')" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)">
+<i class="bi bi-music-note-beamed"></i>
+</a>
+<a class="a move" win12_title="移动" onmouseenter="showdescp(event)" onclick="hidedescp(event); if (!edit_mode) { editMode(); }" onmouseleave="hidedescp(event)">
+<i class="bi bi-arrows-move"></i>
+</a>
+<a class="a addtotb" win12_title="添加到任务栏" onmouseenter="showdescp(event)" onclick="hidedescp(event); widgets.widgets.remove('nowplaying'); widgets.widgets.addToToolbar('nowplaying');" onmouseleave="hidedescp(event)">
+<i class="bi bi-pin-angle"></i>
+</a>
+<a class="a addtodt" win12_title="添加到桌面" onmouseenter="showdescp(event)" onclick="hidedescp(event); widgets.widgets.remove('nowplaying'); widgets.widgets.addToDesktop('nowplaying');" onmouseleave="hidedescp(event)">
+<i class="bi bi-box-arrow-in-right"></i>
+</a>
+<a class="a delete" win12_title="删除" onmouseenter="showdescp(event)" onmouseleave="hidedescp(event)" onclick="hidedescp(event); $(this).parent().removeClass('show'); widgets.widgets.remove('nowplaying');">
+<i class="bi bi-trash"></i>
+</a>
+</div>
+</div>
+<div class="content" onmousedown="widgetsMove(this.parentElement, event);" ontouchstart="widgetsMove(this.parentElement, event);">
+<input class="nowplaying-file" type="file" accept="audio/*">
+<div class="nowplaying-art">
+<i class="bi bi-music-note-beamed"></i>
+</div>
+<div class="nowplaying-info">
+<div class="nowplaying-kicker">Now Playing</div>
+<div class="nowplaying-title">No track selected</div>
+<div class="nowplaying-artist">Import a local audio file</div>
+</div>
+<div class="nowplaying-progressbox">
+<input class="nowplaying-progress" type="range" min="0" max="100" value="0">
+<div class="nowplaying-time">
+<span class="nowplaying-current">0:00</span>
+<span class="nowplaying-duration">0:00</span>
+</div>
+</div>
+<div class="nowplaying-controls">
+<a class="nowplaying-control" onclick="widgets.nowplaying.restart()">
+<i class="bi bi-skip-start-fill"></i>
+</a>
+<a class="nowplaying-control main" onclick="widgets.nowplaying.toggle(event)">
+<i class="bi bi-play-fill nowplaying-play-icon"></i>
+</a>
+<a class="nowplaying-control" onclick="widgets.nowplaying.stop()">
+<i class="bi bi-stop-fill"></i>
+</a>
+<a class="nowplaying-import" onclick="widgets.nowplaying.pickFile(event)">
+<i class="bi bi-folder2-open"></i>
+<span>Import audio</span>
+</a>
+</div>
+</div>
+</div>
+</div>
+
 					<div class="weather">
 						<div class="wg weather template">
 							<div class="titbar">

--- a/desktop.js
+++ b/desktop.js
@@ -878,6 +878,7 @@ const nts = {
                 <a class="a" onclick="closenotice(); widgets.widgets.add('calc');">${lang('计算器', 'calc.name')}</a>
                 <a class="a" onclick="closenotice(); widgets.widgets.add('weather');">${lang('天气', 'nts.addwg.weather')}</a>
                 <a class="a" onclick="closenotice(); widgets.widgets.add('monitor');">${lang('系统性能监视器', 'nts.addwg.monitor')}</a>
+                <a class="a" onclick="closenotice(); widgets.widgets.add(\'nowplaying\');">正在播放</a>
             </list>`,
         btn: [
             { type: 'cancel', text: lang('取消', 'cancel'), js: 'closenotice();' }
@@ -921,6 +922,7 @@ const nts = {
                 <a class="a" onclick="closenotice(); widgets.widgets.addToDesktop('calc');">计算器</a>
                 <a class="a" onclick="closenotice(); widgets.widgets.addToDesktop('weather');">天气</a>
                 <a class="a" onclick="closenotice(); widgets.widgets.addToDesktop('monitor');">系统性能监视器</a>
+                <a class="a" onclick="closenotice(); widgets.widgets.addToDesktop(\'nowplaying\');">正在播放</a>
             </list>`,
         btn: [
             { type: 'cancel', text: lang('取消', 'cancel'), js: 'closenotice();' }

--- a/module/widget.css
+++ b/module/widget.css
@@ -330,3 +330,221 @@
 /* .wg.monitor.toolbar>.content>.text {
     font-siz
 } */
+
+
+/* Now Playing widget */
+.wg.nowplaying {
+    grid-column: auto / span 3;
+    grid-row: auto / span 2;
+    min-height: 166px;
+    background: radial-gradient(circle at top left, color-mix(in srgb, var(--theme-1) 45%, transparent), transparent 46%), linear-gradient(135deg, var(--bg70), var(--bg50));
+    border: 1px solid #ffffff45;
+    box-shadow: 0 12px 36px var(--shadow), inset 0 1px 0 #ffffff40;
+    backdrop-filter: blur(26px) saturate(1.7);
+    -webkit-backdrop-filter: blur(26px) saturate(1.7);
+}
+
+.wg.nowplaying>.content {
+    display: grid;
+    grid-template-columns: 76px 1fr;
+    grid-template-rows: 72px 38px 46px;
+    gap: 0 12px;
+    padding: 34px 14px 12px 14px;
+    box-sizing: border-box;
+}
+
+.wg.nowplaying .nowplaying-file {
+    display: none;
+}
+
+.wg.nowplaying .nowplaying-art {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    width: 76px;
+    height: 76px;
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 34px;
+    background: linear-gradient(135deg, var(--theme-1), var(--theme-2));
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--theme-2) 38%, transparent);
+    overflow: hidden;
+}
+
+.wg.nowplaying.playing .nowplaying-art>.bi {
+    animation: nowplaying-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes nowplaying-pulse {
+    0%, 100% {
+        transform: scale(1);
+        filter: drop-shadow(0 0 0 #ffffff00);
+    }
+
+    50% {
+        transform: scale(1.12) rotate(-4deg);
+        filter: drop-shadow(0 0 10px #ffffffaa);
+    }
+}
+
+.wg.nowplaying .nowplaying-info {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+    align-self: center;
+}
+
+.wg.nowplaying .nowplaying-kicker {
+    font-size: 11px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--text2);
+    margin-bottom: 3px;
+}
+
+.wg.nowplaying .nowplaying-title {
+    font-size: 18px;
+    line-height: 1.15;
+    font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.wg.nowplaying .nowplaying-artist {
+    color: var(--text2);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-top: 4px;
+}
+
+.wg.nowplaying .nowplaying-progressbox {
+    grid-column: 2;
+    grid-row: 2;
+    align-self: center;
+    min-width: 0;
+}
+
+.wg.nowplaying .nowplaying-progress {
+    display: block;
+    width: 100%;
+    accent-color: var(--theme-2);
+    height: 4px;
+}
+
+.wg.nowplaying .nowplaying-time {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: var(--text2);
+    margin-top: -2px;
+}
+
+.wg.nowplaying .nowplaying-controls {
+    grid-column: 1 / span 2;
+    grid-row: 3;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.wg.nowplaying .nowplaying-control,
+.wg.nowplaying .nowplaying-import {
+    height: 34px;
+    border-radius: 999px;
+    background: var(--hover-half);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 1px 0 #ffffff30;
+    transition: 120ms;
+}
+
+.wg.nowplaying .nowplaying-control {
+    width: 38px;
+    font-size: 18px;
+}
+
+.wg.nowplaying .nowplaying-control.main {
+    width: 44px;
+    color: #fff;
+    background: linear-gradient(135deg, var(--theme-1), var(--theme-2));
+    box-shadow: 0 6px 18px color-mix(in srgb, var(--theme-2) 35%, transparent);
+}
+
+.wg.nowplaying .nowplaying-import {
+    flex: 1;
+    gap: 7px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.wg.nowplaying .nowplaying-control:hover,
+.wg.nowplaying .nowplaying-import:hover {
+    filter: brightness(1.12);
+    background-color: var(--hover);
+}
+
+.wg.nowplaying .nowplaying-control:active,
+.wg.nowplaying .nowplaying-import:active {
+    transform: scale(0.94);
+    opacity: .8;
+}
+
+.wg.nowplaying.toolbar {
+    min-width: 250px;
+    height: 100%;
+    min-height: 0;
+}
+
+.wg.nowplaying.toolbar>.content {
+    grid-template-columns: 36px 1fr 36px;
+    grid-template-rows: 1fr;
+    gap: 8px;
+    padding: 8px 10px 6px 10px;
+    margin-top: -22px;
+}
+
+.wg.nowplaying.toolbar .nowplaying-art {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    font-size: 16px;
+    grid-row: 1;
+}
+
+.wg.nowplaying.toolbar .nowplaying-info {
+    grid-column: 2;
+    grid-row: 1;
+}
+
+.wg.nowplaying.toolbar .nowplaying-kicker,
+.wg.nowplaying.toolbar .nowplaying-progressbox,
+.wg.nowplaying.toolbar .nowplaying-control:not(.main),
+.wg.nowplaying.toolbar .nowplaying-import {
+    display: none;
+}
+
+.wg.nowplaying.toolbar .nowplaying-title {
+    font-size: 12px;
+}
+
+.wg.nowplaying.toolbar .nowplaying-artist {
+    font-size: 10px;
+    margin-top: 1px;
+}
+
+.wg.nowplaying.toolbar .nowplaying-controls {
+    grid-column: 3;
+    grid-row: 1;
+}
+
+.wg.nowplaying.toolbar .nowplaying-control.main {
+    width: 32px;
+    height: 32px;
+    font-size: 15px;
+}

--- a/module/widget.js
+++ b/module/widget.js
@@ -26,7 +26,7 @@ let widgets = {
         },
         addToDesktop: (arg) => {
             // widgets.widgets.remove(arg);
-            if ($('.wg.toolbar.' + arg).length != 0) {
+            if ($('.wg.desktop.' + arg).length != 0) {
                 return;
             }
             $('#desktop-widgets')[0].innerHTML += $('#widgets>.widgets>.content>.template>.' + arg).html();
@@ -45,6 +45,155 @@ let widgets = {
             $('#calc-input-widgets').val('0');
         }
     },
+    
+    nowplaying: {
+        audio: null,
+        objectUrl: null,
+        title: 'No track selected',
+        artist: 'Import a local audio file',
+        playing: false,
+        init: () => {
+            if (!widgets.nowplaying.audio) {
+                widgets.nowplaying.audio = new Audio();
+                widgets.nowplaying.audio.addEventListener('timeupdate', widgets.nowplaying.render);
+                widgets.nowplaying.audio.addEventListener('loadedmetadata', widgets.nowplaying.render);
+                widgets.nowplaying.audio.addEventListener('ended', () => {
+                    widgets.nowplaying.playing = false;
+                    widgets.nowplaying.render();
+                });
+            }
+
+            widgets.nowplaying.bind();
+            widgets.nowplaying.render();
+        },
+        bind: () => {
+            $('.wg.nowplaying:not(.template) .nowplaying-file')
+                .off('change.nowplaying')
+                .on('change.nowplaying', function () {
+                    if (this.files && this.files[0]) {
+                        widgets.nowplaying.loadFile(this.files[0]);
+                    }
+
+                    this.value = '';
+                });
+
+            $('.wg.nowplaying:not(.template) .nowplaying-progress')
+                .off('input.nowplaying')
+                .on('input.nowplaying', function () {
+                    if (!widgets.nowplaying.audio || !isFinite(widgets.nowplaying.audio.duration)) {
+                        return;
+                    }
+
+                    widgets.nowplaying.audio.currentTime = Number(this.value);
+                    widgets.nowplaying.render();
+                });
+        },
+        formatTime: (seconds) => {
+            if (!isFinite(seconds)) {
+                return '0:00';
+            }
+
+            let min = Math.floor(seconds / 60);
+            let sec = Math.floor(seconds % 60).toString().padStart(2, '0');
+            return `${min}:${sec}`;
+        },
+        pickFile: (event) => {
+            let widget = $(event.currentTarget).closest('.wg.nowplaying');
+            widget.find('.nowplaying-file').trigger('click');
+        },
+        loadFile: (file) => {
+            if (!file) {
+                return;
+            }
+
+            if (widgets.nowplaying.objectUrl) {
+                URL.revokeObjectURL(widgets.nowplaying.objectUrl);
+            }
+
+            widgets.nowplaying.objectUrl = URL.createObjectURL(file);
+            widgets.nowplaying.title = file.name.replace(/\.[^.]+$/, '');
+            widgets.nowplaying.artist = 'Local audio file';
+            widgets.nowplaying.audio.src = widgets.nowplaying.objectUrl;
+
+            widgets.nowplaying.audio.play().then(() => {
+                widgets.nowplaying.playing = true;
+                widgets.nowplaying.render();
+            }).catch(() => {
+                widgets.nowplaying.playing = false;
+                widgets.nowplaying.render();
+            });
+        },
+        play: () => {
+            if (!widgets.nowplaying.audio || !widgets.nowplaying.audio.src) {
+                $('.wg.nowplaying:not(.template):first .nowplaying-file').trigger('click');
+                return;
+            }
+
+            widgets.nowplaying.audio.play().then(() => {
+                widgets.nowplaying.playing = true;
+                widgets.nowplaying.render();
+            }).catch(() => {
+                widgets.nowplaying.playing = false;
+                widgets.nowplaying.render();
+            });
+        },
+        pause: () => {
+            if (widgets.nowplaying.audio) {
+                widgets.nowplaying.audio.pause();
+            }
+
+            widgets.nowplaying.playing = false;
+            widgets.nowplaying.render();
+        },
+        toggle: () => {
+            if (widgets.nowplaying.playing) {
+                widgets.nowplaying.pause();
+            }
+            else {
+                widgets.nowplaying.play();
+            }
+        },
+        stop: () => {
+            if (widgets.nowplaying.audio) {
+                widgets.nowplaying.audio.pause();
+                widgets.nowplaying.audio.currentTime = 0;
+            }
+
+            widgets.nowplaying.playing = false;
+            widgets.nowplaying.render();
+        },
+        restart: () => {
+            if (!widgets.nowplaying.audio || !widgets.nowplaying.audio.src) {
+                return;
+            }
+
+            widgets.nowplaying.audio.currentTime = 0;
+            widgets.nowplaying.play();
+        },
+        render: () => {
+            let audio = widgets.nowplaying.audio;
+            let current = audio ? audio.currentTime || 0 : 0;
+            let duration = audio && isFinite(audio.duration) ? audio.duration : 0;
+
+            $('.wg.nowplaying:not(.template)').toggleClass('playing', widgets.nowplaying.playing);
+            $('.wg.nowplaying:not(.template) .nowplaying-title').text(widgets.nowplaying.title);
+            $('.wg.nowplaying:not(.template) .nowplaying-artist').text(widgets.nowplaying.artist);
+            $('.wg.nowplaying:not(.template) .nowplaying-current').text(widgets.nowplaying.formatTime(current));
+            $('.wg.nowplaying:not(.template) .nowplaying-duration').text(widgets.nowplaying.formatTime(duration));
+            $('.wg.nowplaying:not(.template) .nowplaying-progress')
+                .attr('max', duration || 100)
+                .val(current);
+
+            $('.wg.nowplaying:not(.template) .nowplaying-play-icon')
+                .removeClass('bi-play-fill bi-pause-fill')
+                .addClass(widgets.nowplaying.playing ? 'bi-pause-fill' : 'bi-play-fill');
+        },
+        remove: () => {
+            widgets.nowplaying.pause();
+        }
+    },
+
+
     weather: {
         init: () => {
             widgets.weather.update();


### PR DESCRIPTION
## Changes
- Added the Now Playing widget template.
- Added Now Playing to the widget panel options.
- Added Now Playing to desktop widget options.
- Added Now Playing to toolbar/taskbar widget options where supported.
- Added local audio playback with play, pause, stop, restart, and progress display.
- Added focused widget styles.

## Testing
- Ran node syntax check for module/widget.js.
- Ran git diff whitespace check.
- Confirmed only the intended widget files are committed.