### PR TITLE
Fn/try to capture and use the built in browser in windows 12 when opening a browser on the desktop version

### DIFF
--- a/desktop.html
+++ b/desktop.html
@@ -2335,6 +2335,7 @@ toggletheme() 切换主题
 					}
 				</style>
 			</div>
+			<div id="edge-external-status" style="display:none;padding:18px;text-align:center;overflow:auto;white-space:pre-wrap;"></div>
 			<iframe frameborder="0" class="0 show" onmousemove="if(apps.edge.fuls){$('.edge>.titbar').hide();$('.edge>.content>.tool').hide()}">
 			</iframe>
 		</div>
@@ -3278,6 +3279,7 @@ toggletheme() 切换主题
 	<script defer src="data/tasks.js"></script>
 	<script defer src="scripts/utils.js"></script>
 
+	<script defer src="module/browser-manager.js"></script>
 	<script defer src="module/apps.js"></script>
 	<script defer src="desktop.js"></script>
 	<script defer src="module/window.js"></script>

--- a/desktop.js
+++ b/desktop.js
@@ -107,6 +107,56 @@ function isTauriApp() {
     return !!((window.win12Native && window.win12Native.isTauri && window.win12Native.isTauri()) || (window.__TAURI__ && window.__TAURI__.core));
 }
 
+// Tauri's WebView does not reliably create a new window for external links.
+// Route HTTP(S) links through the Win12 Edge app instead, so links from both
+// static markup and dynamically-created app content behave consistently.
+function isExternalHttpUrl(value) {
+    if (!value) return false;
+    try {
+        const url = new URL(value, window.location.href);
+        return (url.protocol === 'http:' || url.protocol === 'https:') &&
+            url.origin !== window.location.origin;
+    } catch (_) {
+        return false;
+    }
+}
+
+function openExternalInWin12Browser(value) {
+    if (!isTauriApp() || !isExternalHttpUrl(value)) return false;
+
+    const url = new URL(value, window.location.href).href;
+    openapp('edge');
+    window.setTimeout(() => {
+        if (window.apps && apps.edge && typeof apps.edge.newtab === 'function' &&
+            typeof apps.edge.goto === 'function') {
+            apps.edge.newtab();
+            apps.edge.goto(url);
+        }
+    }, 300);
+    return true;
+}
+
+// Capture normal anchors, including anchors added after startup. Keep links
+// inside the Win12 app and same-origin navigation unchanged.
+document.addEventListener('click', (event) => {
+    if (!isTauriApp() || event.defaultPrevented || event.button !== 0) return;
+    const anchor = event.target.closest && event.target.closest('a[href]');
+    if (!anchor || anchor.hasAttribute('download')) return;
+    const href = anchor.href;
+    if (!isExternalHttpUrl(href)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    openExternalInWin12Browser(href);
+}, true);
+
+// A number of existing links call window.open directly. Preserve the native
+// behavior outside Tauri, but use the in-app browser for desktop external URLs.
+const nativeWindowOpen = window.open.bind(window);
+window.open = function (url, ...args) {
+    if (openExternalInWin12Browser(url)) return null;
+    return nativeWindowOpen(url, ...args);
+};
+
 function getAboutAppTitle() {
     if (!isTauriApp()) return lang('关于 Win12 网页版', 'about.name');
     if (langcode == 'en') return 'About Win12-desktop';

--- a/desktop.js
+++ b/desktop.js
@@ -127,7 +127,7 @@ function openExternalInWin12Browser(value) {
     const url = new URL(value, window.location.href).href;
     openapp('edge');
     window.setTimeout(() => {
-        if (window.apps && apps.edge && typeof apps.edge.newtab === 'function' &&
+if (apps.edge && typeof apps.edge.newtab === 'function' &&
             typeof apps.edge.goto === 'function') {
             apps.edge.newtab();
             apps.edge.goto(url);

--- a/desktop.js
+++ b/desktop.js
@@ -127,7 +127,7 @@ function openExternalInWin12Browser(value) {
     const url = new URL(value, window.location.href).href;
     openapp('edge');
     window.setTimeout(() => {
-if (apps.edge && typeof apps.edge.newtab === 'function' &&
+        if (apps.edge && typeof apps.edge.newtab === 'function' &&
             typeof apps.edge.goto === 'function') {
             apps.edge.newtab();
             apps.edge.goto(url);

--- a/module/apps.js
+++ b/module/apps.js
@@ -2670,7 +2670,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 activeIframe.show();
                 $('#edge-external-status').hide().text('');
             }
-            $('#win-edge>.tool>input.url').val(activeIframe.attr('src') == 'mainpage.html' ? '' : activeIframe.attr('src'));
+            if (!activeExternal) $('#win-edge>.tool>input.url').val(activeIframe.attr('src') === 'mainpage.html' ? '' : activeIframe.attr('src'));
             $('#win-edge>.tool>input.rename').removeClass('show');
             apps.edge.checkHistory(apps.edge.tabs[apps.edge.now][0]);
             Object.entries(apps.edge.externalWindows).forEach(([tab, webview]) => {

--- a/module/apps.js
+++ b/module/apps.js
@@ -2552,6 +2552,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
         max: false,
         fuls: false,
         externalUrl: null,
+        externalUrls: Object.create(null),
         externalWindows: Object.create(null),
         b1: false, b2: false, b3: false,
         newtab: () => {
@@ -2596,6 +2597,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 window.close().catch(() => {});
                 delete apps.edge.externalWindows[tab];
             }
+            delete apps.edge.externalUrls[tab];
         },
         closeAllExternalWindows: () => {
             Object.keys(apps.edge.externalWindows).forEach(tab => apps.edge.closeExternalWindow(tab));
@@ -2656,11 +2658,21 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
         },
         tab: (c) => {
             $('#win-edge>iframe.show').removeClass('show');
-            $('#win-edge>iframe.' + apps.edge.tabs[c][0]).addClass('show');
-            $('#win-edge>.tool>input.url').val($('#win-edge>iframe.' + apps.edge.tabs[c][0]).attr('src') == 'mainpage.html' ? '' : $('#win-edge>iframe.' + apps.edge.tabs[c][0]).attr('src'));
+            const activeTab = apps.edge.tabs[c][0];
+            const activeIframe = $('#win-edge>iframe.' + activeTab);
+            const activeExternal = apps.edge.externalWindows[activeTab];
+            activeIframe.addClass('show');
+            if (activeExternal) {
+                activeIframe.hide();
+                $('#edge-external-status').text('当前标签页使用独立 WebView 渲染').show();
+                $('#win-edge>.tool>input.url').val(apps.edge.externalUrls[activeTab] || '');
+            } else {
+                activeIframe.show();
+                $('#edge-external-status').hide().text('');
+            }
+            $('#win-edge>.tool>input.url').val(activeIframe.attr('src') == 'mainpage.html' ? '' : activeIframe.attr('src'));
             $('#win-edge>.tool>input.rename').removeClass('show');
             apps.edge.checkHistory(apps.edge.tabs[apps.edge.now][0]);
-            const activeTab = apps.edge.tabs[c][0];
             Object.entries(apps.edge.externalWindows).forEach(([tab, webview]) => {
                 if (tab === activeTab) {
                     webview.show().catch(() => {
@@ -2722,6 +2734,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 const tab = apps.edge.tabs[apps.edge.now][0];
                 apps.edge.closeExternalWindow(tab);
                 apps.edge.externalUrl = target;
+                apps.edge.externalUrls[tab] = target;
                 $('#win-edge>.tool>input.url').val(target);
                 apps.edge.setExternalStatus('正在启动系统 Microsoft Edge…\n' + target);
                 browser.openExternal(target, {

--- a/module/apps.js
+++ b/module/apps.js
@@ -2766,7 +2766,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 return;
             }
 
-apps.edge.closeExternalWindow(apps.edge.tabs[apps.edge.now][0]);
+            apps.edge.closeExternalWindow(apps.edge.tabs[apps.edge.now][0]);
             if (wifiStatus == false) {
                 m_tab.rename('edge', u);
                 $('#win-edge>iframe.show').attr('src', '.data/disconnected' + (isDark ? '_dark' : '') + '.html');

--- a/module/apps.js
+++ b/module/apps.js
@@ -2730,7 +2730,9 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             // In hybrid/external mode external pages are rendered by the
             // system Edge app. Win12 keeps only a launch/status placeholder;
             // it does not mirror the external page's history in its iframe.
-            if (targetType === 'external' && browser.mode !== 'embedded') {
+            const useDesktopExternalWebview = browser.mode !== 'embedded' &&
+                window.win12Native?.isTauri?.();
+            if (targetType === 'external' && useDesktopExternalWebview) {
                 const tab = apps.edge.tabs[apps.edge.now][0];
                 apps.edge.closeExternalWindow(tab);
                 apps.edge.externalUrl = target;

--- a/module/apps.js
+++ b/module/apps.js
@@ -2766,7 +2766,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 return;
             }
 
-            apps.edge.clearExternalStatus();
+apps.edge.closeExternalWindow(apps.edge.tabs[apps.edge.now][0]);
             if (wifiStatus == false) {
                 m_tab.rename('edge', u);
                 $('#win-edge>iframe.show').attr('src', '.data/disconnected' + (isDark ? '_dark' : '') + '.html');

--- a/module/apps.js
+++ b/module/apps.js
@@ -2552,6 +2552,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
         max: false,
         fuls: false,
         externalUrl: null,
+        externalWindows: Object.create(null),
         b1: false, b2: false, b3: false,
         newtab: () => {
             m_tab.newtab('edge', '新建标签页');
@@ -2578,6 +2579,13 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             const status = $('#edge-external-status');
             status.text(message).css({ display: 'block', color: error ? '#c42b1c' : '' });
             $('#win-edge>iframe.show').hide();
+        },
+        closeExternalWindow: (tab) => {
+            const window = apps.edge.externalWindows[tab];
+            if (window) {
+                window.close().catch(() => {});
+                delete apps.edge.externalWindows[tab];
+            }
         },
         clearExternalStatus: () => {
             $('#edge-external-status').hide().text('');
@@ -2639,6 +2647,15 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             $('#win-edge>.tool>input.url').val($('#win-edge>iframe.' + apps.edge.tabs[c][0]).attr('src') == 'mainpage.html' ? '' : $('#win-edge>iframe.' + apps.edge.tabs[c][0]).attr('src'));
             $('#win-edge>.tool>input.rename').removeClass('show');
             apps.edge.checkHistory(apps.edge.tabs[apps.edge.now][0]);
+            const activeTab = apps.edge.tabs[c][0];
+            Object.entries(apps.edge.externalWindows).forEach(([tab, webview]) => {
+                if (tab === activeTab) {
+                    webview.show().catch(() => {});
+                    webview.setFocus().catch(() => {});
+                } else {
+                    webview.hide().catch(() => {});
+                }
+            });
         },
         c_rename: (c) => {
             m_tab.tab('edge', c);
@@ -2683,11 +2700,14 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             // system Edge app. Win12 keeps only a launch/status placeholder;
             // it does not mirror the external page's history in its iframe.
             if (targetType === 'external' && browser.mode !== 'embedded') {
+                const tab = apps.edge.tabs[apps.edge.now][0];
+                apps.edge.closeExternalWindow(tab);
                 apps.edge.externalUrl = target;
                 $('#win-edge>.tool>input.url').val(target);
                 apps.edge.setExternalStatus('正在启动系统 Microsoft Edge…\n' + target);
-                browser.openExternal(target).then(() => {
-                    apps.edge.setExternalStatus('已在系统 Microsoft Edge 中打开\n' + target);
+                browser.openExternal(target, { label: 'edge-' + tab, title: 'Win12 Edge', parent: 'main' }).then((webview) => {
+                    apps.edge.externalWindows[tab] = webview;
+                    apps.edge.setExternalStatus('外部网页已在 Win12 Edge 窗口中打开\n' + target);
                 }).catch((error) => {
                     apps.edge.setExternalStatus('无法打开外部网页\n' + (error?.message || error), true);
                 });

--- a/module/apps.js
+++ b/module/apps.js
@@ -2580,6 +2580,16 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             status.text(message).css({ display: 'block', color: error ? '#c42b1c' : '' });
             $('#win-edge>iframe.show').hide();
         },
+        updateExternalTitle: (tab, title) => {
+            const item = apps.edge.tabs.find(entry => entry[0] === tab);
+            if (!item || !title) return;
+            item[1] = title;
+            m_tab.settabs('edge');
+        },
+        updateExternalUrl: (tab, url) => {
+            const index = apps.edge.tabs.findIndex(entry => entry[0] === tab);
+            if (index === apps.edge.now && url) $('#win-edge>.tool>input.url').val(url);
+        },
         closeExternalWindow: (tab) => {
             const window = apps.edge.externalWindows[tab];
             if (window) {
@@ -2718,14 +2728,13 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                     onDestroyed: (label) => {
                         const destroyedTab = label.replace(/^edge-/, '');
                         delete apps.edge.externalWindows[destroyedTab];
-                    }
+                    },
+                    onTitle: (title) => apps.edge.updateExternalTitle(tab, title),
+                    onUrl: (url) => apps.edge.updateExternalUrl(tab, url)
                 }).then((webview) => {
                     apps.edge.externalWindows[tab] = webview;
-                    setTimeout(() => {
-                        $('#edge-external-status').hide().text('');
-                        $('#win-edge>iframe.show').hide();
-                    }, 0);
                     apps.edge.setExternalStatus('外部网页已在 Win12 Edge 窗口中打开\n' + target);
+                    apps.edge.setExternalStatus('当前标签页使用独立 WebView 渲染');
                 }).catch((error) => {
                     apps.edge.setExternalStatus('无法打开外部网页\n' + (error?.message || error), true);
                 });

--- a/module/apps.js
+++ b/module/apps.js
@@ -2650,10 +2650,16 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             const activeTab = apps.edge.tabs[c][0];
             Object.entries(apps.edge.externalWindows).forEach(([tab, webview]) => {
                 if (tab === activeTab) {
-                    webview.show().catch(() => {});
-                    webview.setFocus().catch(() => {});
+                    webview.show().catch(() => {
+                        delete apps.edge.externalWindows[tab];
+                    });
+                    webview.setFocus().catch(() => {
+                        delete apps.edge.externalWindows[tab];
+                    });
                 } else {
-                    webview.hide().catch(() => {});
+                    webview.hide().catch(() => {
+                        delete apps.edge.externalWindows[tab];
+                    });
                 }
             });
         },
@@ -2705,8 +2711,20 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 apps.edge.externalUrl = target;
                 $('#win-edge>.tool>input.url').val(target);
                 apps.edge.setExternalStatus('正在启动系统 Microsoft Edge…\n' + target);
-                browser.openExternal(target, { label: 'edge-' + tab, title: 'Win12 Edge', parent: 'main' }).then((webview) => {
+                browser.openExternal(target, {
+                    label: 'edge-' + tab,
+                    title: 'Win12 Edge',
+                    parent: 'main',
+                    onDestroyed: (label) => {
+                        const destroyedTab = label.replace(/^edge-/, '');
+                        delete apps.edge.externalWindows[destroyedTab];
+                    }
+                }).then((webview) => {
                     apps.edge.externalWindows[tab] = webview;
+                    setTimeout(() => {
+                        $('#edge-external-status').hide().text('');
+                        $('#win-edge>iframe.show').hide();
+                    }, 0);
                     apps.edge.setExternalStatus('外部网页已在 Win12 Edge 窗口中打开\n' + target);
                 }).catch((error) => {
                     apps.edge.setExternalStatus('无法打开外部网页\n' + (error?.message || error), true);

--- a/module/apps.js
+++ b/module/apps.js
@@ -2597,6 +2597,9 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 delete apps.edge.externalWindows[tab];
             }
         },
+        closeAllExternalWindows: () => {
+            Object.keys(apps.edge.externalWindows).forEach(tab => apps.edge.closeExternalWindow(tab));
+        },
         clearExternalStatus: () => {
             $('#edge-external-status').hide().text('');
             $('#win-edge>iframe.show').show();

--- a/module/apps.js
+++ b/module/apps.js
@@ -2736,11 +2736,18 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
                 apps.edge.externalUrl = target;
                 apps.edge.externalUrls[tab] = target;
                 $('#win-edge>.tool>input.url').val(target);
+                const contentRect = $('#win-edge>iframe.show')[0]?.getBoundingClientRect();
                 apps.edge.setExternalStatus('正在启动系统 Microsoft Edge…\n' + target);
                 browser.openExternal(target, {
                     label: 'edge-' + tab,
                     title: 'Win12 Edge',
                     parent: 'main',
+                    bounds: contentRect && {
+                        x: contentRect.left,
+                        y: contentRect.top,
+                        width: contentRect.width,
+                        height: contentRect.height
+                    },
                     onDestroyed: (label) => {
                         const destroyedTab = label.replace(/^edge-/, '');
                         delete apps.edge.externalWindows[destroyedTab];

--- a/module/apps.js
+++ b/module/apps.js
@@ -2537,6 +2537,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
     },
     edge: {
         init: () => {
+            browser.configure(localStorage.getItem('win12.browser.mode') || 'hybrid');
             $('#win-edge>iframe').remove();
             apps.edge.tabs = [];
             apps.edge.len = 0;
@@ -2550,6 +2551,7 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
         reloadElt: '<loading class="reloading"><svg viewBox="0 0 16 16"><circle cx="8px" cy="8px" r="5px"></circle><circle cx="8px" cy="8px" r="5px"></circle></svg></loading>',
         max: false,
         fuls: false,
+        externalUrl: null,
         b1: false, b2: false, b3: false,
         newtab: () => {
             m_tab.newtab('edge', '新建标签页');
@@ -2571,6 +2573,15 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             };
             m_tab.tab('edge', apps.edge.tabs.length - 1);
             apps.edge.checkHistory(apps.edge.tabs[apps.edge.now][0]);
+        },
+        setExternalStatus: (message, error = false) => {
+            const status = $('#edge-external-status');
+            status.text(message).css({ display: 'block', color: error ? '#c42b1c' : '' });
+            $('#win-edge>iframe.show').hide();
+        },
+        clearExternalStatus: () => {
+            $('#edge-external-status').hide().text('');
+            $('#win-edge>iframe.show').show();
         },
         fullscreen: () => {
             if (!apps.edge.max) {
@@ -2661,6 +2672,29 @@ Micrȯsoft Windows [版本 12.0.39035.7324]
             }
         },
         goto: (u, clear = true) => {
+            const input = String(u || '').trim();
+            const target = /^https?:\/\//i.test(input) ? input :
+                (/^mainpage\.html$/.test(input) ? input :
+                    (/^[^\s/]+\.[^\s/]+/.test(input) ? 'http://' + input :
+                        'https://bing.com/search?q=' + encodeURIComponent(input)));
+            const targetType = browser.classify(target);
+
+            // In hybrid/external mode external pages are rendered by the
+            // system Edge app. Win12 keeps only a launch/status placeholder;
+            // it does not mirror the external page's history in its iframe.
+            if (targetType === 'external' && browser.mode !== 'embedded') {
+                apps.edge.externalUrl = target;
+                $('#win-edge>.tool>input.url').val(target);
+                apps.edge.setExternalStatus('正在启动系统 Microsoft Edge…\n' + target);
+                browser.openExternal(target).then(() => {
+                    apps.edge.setExternalStatus('已在系统 Microsoft Edge 中打开\n' + target);
+                }).catch((error) => {
+                    apps.edge.setExternalStatus('无法打开外部网页\n' + (error?.message || error), true);
+                });
+                return;
+            }
+
+            apps.edge.clearExternalStatus();
             if (wifiStatus == false) {
                 m_tab.rename('edge', u);
                 $('#win-edge>iframe.show').attr('src', '.data/disconnected' + (isDark ? '_dark' : '') + '.html');

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -27,7 +27,7 @@ window.browser = {
         window.location.href = url;
     },
 
-    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main', onDestroyed, onTitle, onUrl } = {}) {
+    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main', bounds, onDestroyed, onTitle, onUrl } = {}) {
         const parsed = new URL(url, window.location.href);
         if (!['http:', 'https:'].includes(parsed.protocol) || /[\u0000-\u001f\u007f]/.test(parsed.href)) {
             throw new Error('不允许打开此类型的链接');
@@ -37,16 +37,20 @@ window.browser = {
         if (window.win12Native?.isTauri?.() && Webview) {
             if (!label) throw new Error('外部浏览器窗口缺少标签标识');
             const host = document.querySelector('#win-edge>iframe.show');
-            const rect = host?.getBoundingClientRect() || { left: 0, top: 0, width: 1100, height: 760 };
+            const rect = bounds || host?.getBoundingClientRect() || { left: 0, top: 0, width: 1100, height: 760 };
+            const left = bounds ? bounds.x : rect.left;
+            const top = bounds ? bounds.y : rect.top;
+            const width = bounds ? bounds.width : rect.width;
+            const height = bounds ? bounds.height : rect.height;
             const parentWindow = window.__TAURI__.window?.getCurrentWindow?.();
             if (!parentWindow) throw new Error('无法获取 Win12 主窗口');
             return new Promise((resolve, reject) => {
                 const webview = new Webview(parentWindow, label, {
                     url: parsed.href,
-                    x: Math.max(0, Math.round(rect.left)),
-                    y: Math.max(0, Math.round(rect.top)),
-                    width: Math.max(720, Math.round(rect.width)),
-                    height: Math.max(520, Math.round(rect.height))
+                    x: Math.max(0, Math.round(left)),
+                    y: Math.max(0, Math.round(top)),
+                    width: Math.max(720, Math.round(width)),
+                    height: Math.max(520, Math.round(height))
                 });
                 webview.once('tauri://destroyed', () => {
                     if (typeof onDestroyed === 'function') onDestroyed(label);
@@ -59,8 +63,8 @@ window.browser = {
                     }
                 }).catch(() => {});
                 webview.once('tauri://created', () => resolve(webview));
-                webview.setPosition({ x: Math.max(0, Math.round(rect.left)), y: Math.max(0, Math.round(rect.top)) }).catch(() => {});
-                webview.setSize({ width: Math.max(720, Math.round(rect.width)), height: Math.max(520, Math.round(rect.height)) }).catch(() => {});
+                webview.setPosition({ x: Math.max(0, Math.round(left)), y: Math.max(0, Math.round(top)) }).catch(() => {});
+                webview.setSize({ width: Math.max(720, Math.round(width)), height: Math.max(520, Math.round(height)) }).catch(() => {});
                 webview.once('tauri://error', event => reject(new Error(String(event.payload || '无法创建 WebView 窗口'))));
             });
         }

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -59,6 +59,8 @@ window.browser = {
                     }
                 }).catch(() => {});
                 webview.once('tauri://created', () => resolve(webview));
+                webview.setPosition({ x: Math.max(0, Math.round(rect.left)), y: Math.max(0, Math.round(rect.top)) }).catch(() => {});
+                webview.setSize({ width: Math.max(720, Math.round(rect.width)), height: Math.max(520, Math.round(rect.height)) }).catch(() => {});
                 webview.once('tauri://error', event => reject(new Error(String(event.payload || '无法创建 WebView 窗口'))));
             });
         }

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -1,0 +1,57 @@
+'use strict';
+
+// Browser Manager deliberately contains no tab, history, or UI state.
+// It only decides where a URL should be rendered and performs the handoff.
+window.browser = {
+    mode: 'hybrid',
+
+    configure(mode) {
+        this.mode = ['hybrid', 'embedded', 'external'].includes(mode) ? mode : 'hybrid';
+    },
+
+    classify(url) {
+        if (url === 'mainpage.html' || /^data\//.test(url) || /^\.\/?data\//.test(url)) {
+            return 'internal';
+        }
+        try {
+            const parsed = new URL(url, window.location.href);
+            return parsed.origin === window.location.origin ? 'internal' :
+                ['http:', 'https:'].includes(parsed.protocol) ? 'external' : 'invalid';
+        } catch (_) {
+            return 'invalid';
+        }
+    },
+
+    openInternal(url, handlers = {}) {
+        if (typeof handlers.open === 'function') return handlers.open(url);
+        window.location.href = url;
+    },
+
+    async openExternal(url, { fallback = true } = {}) {
+        const parsed = new URL(url, window.location.href);
+        if (!['http:', 'https:'].includes(parsed.protocol) || /[\u0000-\u001f\u007f]/.test(parsed.href)) {
+            throw new Error('不允许打开此类型的链接');
+        }
+
+        if (window.win12Native && window.win12Native.isTauri()) {
+            try {
+                return await window.win12Native.openExternalUrl(parsed.href);
+            } catch (error) {
+                if (!fallback) throw error;
+                return this.fallback(parsed.href, error);
+            }
+        }
+
+        return this.fallback(parsed.href);
+    },
+
+    fallback(url, originalError) {
+        if (window.__TAURI__?.opener?.openUrl) {
+            return window.__TAURI__.opener.openUrl(url);
+        }
+        if (!window.win12Native?.isTauri?.()) {
+            return window.open(url, '_blank');
+        }
+        throw originalError || new Error('无法启动系统浏览器');
+    }
+};

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -33,31 +33,20 @@ window.browser = {
             throw new Error('不允许打开此类型的链接');
         }
 
-        const WebviewWindow = window.__TAURI__?.webviewWindow?.WebviewWindow;
-        if (window.win12Native?.isTauri?.() && WebviewWindow) {
+        const Webview = window.__TAURI__?.webview?.Webview;
+        if (window.win12Native?.isTauri?.() && Webview) {
             if (!label) throw new Error('外部浏览器窗口缺少标签标识');
-            let placement = {};
-            try {
-                const mainWindow = window.__TAURI__.window?.getCurrentWindow?.();
-                if (mainWindow) {
-                    const [position, size] = await Promise.all([mainWindow.outerPosition(), mainWindow.innerSize()]);
-                    placement = { x: position.x, y: position.y, width: size.width, height: size.height };
-                }
-            } catch (_) {}
+            const host = document.querySelector('#win-edge>iframe.show');
+            const rect = host?.getBoundingClientRect() || { left: 0, top: 0, width: 1100, height: 760 };
+            const parentWindow = window.__TAURI__.window?.getCurrentWindow?.();
+            if (!parentWindow) throw new Error('无法获取 Win12 主窗口');
             return new Promise((resolve, reject) => {
-                const webview = new WebviewWindow(label, {
+                const webview = new Webview(parentWindow, label, {
                     url: parsed.href,
-                    title,
-                    parent,
-                    x: placement.x,
-                    y: placement.y,
-                    center: placement.x === undefined,
-                    decorations: false,
-                    resizable: true,
-                    focus: true,
-                    visible: true,
-                    width: placement.width || 1100,
-                    height: placement.height || 760
+                    x: Math.max(0, Math.round(rect.left)),
+                    y: Math.max(0, Math.round(rect.top)),
+                    width: Math.max(720, Math.round(rect.width)),
+                    height: Math.max(520, Math.round(rect.height))
                 });
                 webview.once('tauri://destroyed', () => {
                     if (typeof onDestroyed === 'function') onDestroyed(label);

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -27,7 +27,7 @@ window.browser = {
         window.location.href = url;
     },
 
-    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main', onDestroyed } = {}) {
+    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main', onDestroyed, onTitle, onUrl } = {}) {
         const parsed = new URL(url, window.location.href);
         if (!['http:', 'https:'].includes(parsed.protocol) || /[\u0000-\u001f\u007f]/.test(parsed.href)) {
             throw new Error('不允许打开此类型的链接');
@@ -36,22 +36,39 @@ window.browser = {
         const WebviewWindow = window.__TAURI__?.webviewWindow?.WebviewWindow;
         if (window.win12Native?.isTauri?.() && WebviewWindow) {
             if (!label) throw new Error('外部浏览器窗口缺少标签标识');
+            let placement = {};
+            try {
+                const mainWindow = window.__TAURI__.window?.getCurrentWindow?.();
+                if (mainWindow) {
+                    const [position, size] = await Promise.all([mainWindow.outerPosition(), mainWindow.innerSize()]);
+                    placement = { x: position.x, y: position.y, width: size.width, height: size.height };
+                }
+            } catch (_) {}
             return new Promise((resolve, reject) => {
                 const webview = new WebviewWindow(label, {
                     url: parsed.href,
                     title,
                     parent,
-                    center: true,
-                    decorations: true,
+                    x: placement.x,
+                    y: placement.y,
+                    center: placement.x === undefined,
+                    decorations: false,
                     resizable: true,
                     focus: true,
                     visible: true,
-                    width: 1100,
-                    height: 760
+                    width: placement.width || 1100,
+                    height: placement.height || 760
                 });
                 webview.once('tauri://destroyed', () => {
                     if (typeof onDestroyed === 'function') onDestroyed(label);
                 });
+                webview.listen('tauri://page-load', (event) => {
+                    const payload = event.payload || {};
+                    if (payload.url && typeof onUrl === 'function') onUrl(payload.url);
+                    if (typeof onTitle === 'function') {
+                        webview.title().then(onTitle).catch(() => {});
+                    }
+                }).catch(() => {});
                 webview.once('tauri://created', () => resolve(webview));
                 webview.once('tauri://error', event => reject(new Error(String(event.payload || '无法创建 WebView 窗口'))));
             });

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -44,6 +44,11 @@ window.browser = {
             const height = bounds ? bounds.height : rect.height;
             const parentWindow = window.__TAURI__.window?.getCurrentWindow?.();
             if (!parentWindow) throw new Error('无法获取 Win12 主窗口');
+            const existing = await Webview.getByLabel(label);
+            if (existing) {
+                await existing.close().catch(() => {});
+                await new Promise(resolve => setTimeout(resolve, 50));
+            }
             return new Promise((resolve, reject) => {
                 const webview = new Webview(parentWindow, label, {
                     url: parsed.href,

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -27,7 +27,7 @@ window.browser = {
         window.location.href = url;
     },
 
-    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main' } = {}) {
+    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main', onDestroyed } = {}) {
         const parsed = new URL(url, window.location.href);
         if (!['http:', 'https:'].includes(parsed.protocol) || /[\u0000-\u001f\u007f]/.test(parsed.href)) {
             throw new Error('不允许打开此类型的链接');
@@ -48,6 +48,9 @@ window.browser = {
                     visible: true,
                     width: 1100,
                     height: 760
+                });
+                webview.once('tauri://destroyed', () => {
+                    if (typeof onDestroyed === 'function') onDestroyed(label);
                 });
                 webview.once('tauri://created', () => resolve(webview));
                 webview.once('tauri://error', event => reject(new Error(String(event.payload || '无法创建 WebView 窗口'))));

--- a/module/browser-manager.js
+++ b/module/browser-manager.js
@@ -27,19 +27,31 @@ window.browser = {
         window.location.href = url;
     },
 
-    async openExternal(url, { fallback = true } = {}) {
+    async openExternal(url, { label, title = 'Microsoft Edge', parent = 'main' } = {}) {
         const parsed = new URL(url, window.location.href);
         if (!['http:', 'https:'].includes(parsed.protocol) || /[\u0000-\u001f\u007f]/.test(parsed.href)) {
             throw new Error('不允许打开此类型的链接');
         }
 
-        if (window.win12Native && window.win12Native.isTauri()) {
-            try {
-                return await window.win12Native.openExternalUrl(parsed.href);
-            } catch (error) {
-                if (!fallback) throw error;
-                return this.fallback(parsed.href, error);
-            }
+        const WebviewWindow = window.__TAURI__?.webviewWindow?.WebviewWindow;
+        if (window.win12Native?.isTauri?.() && WebviewWindow) {
+            if (!label) throw new Error('外部浏览器窗口缺少标签标识');
+            return new Promise((resolve, reject) => {
+                const webview = new WebviewWindow(label, {
+                    url: parsed.href,
+                    title,
+                    parent,
+                    center: true,
+                    decorations: true,
+                    resizable: true,
+                    focus: true,
+                    visible: true,
+                    width: 1100,
+                    height: 760
+                });
+                webview.once('tauri://created', () => resolve(webview));
+                webview.once('tauri://error', event => reject(new Error(String(event.payload || '无法创建 WebView 窗口'))));
+            });
         }
 
         return this.fallback(parsed.href);

--- a/module/tab.js
+++ b/module/tab.js
@@ -102,6 +102,9 @@ let m_tab={
             $(`.window.${appn}>.titbar>.tabs>.tab.${_id}`).addClass('left');
         }
         setTimeout(() => {
+            if (appn === 'edge' && apps.edge.closeExternalWindow) {
+                apps.edge.closeExternalWindow(app.tabs[c][0]);
+            }
             $(`#win-${appn}>iframe.${app.tabs[c][0]}`).remove();
             app.tabs.splice(c, 1);
             m_tab.settabs(appn);

--- a/module/window.js
+++ b/module/window.js
@@ -28,6 +28,9 @@ function showwin(name) {
 }
 
 function hidewin(name, arg = 'window') {
+    if (name == 'edge' && apps.edge && apps.edge.closeAllExternalWindows) {
+        apps.edge.closeAllExternalWindows();
+    }
     $('.window.' + name).removeClass('notrans');
     $('.window.' + name).removeClass('max');
     $('.window.' + name).removeClass('show');

--- a/tauri/tauri_api.js
+++ b/tauri/tauri_api.js
@@ -33,6 +33,10 @@ window.win12Native = {
     await window.__TAURI__.core.invoke("write_settings", { json: JSON.stringify(settings) });
     return true;
   },
+  async openExternalUrl(url) {
+    if (!this.isTauri()) return false;
+    return await window.__TAURI__.core.invoke("open_external_url", { url });
+  },
   async pingHost(host, ipv6 = false, onOutput = null) {
     if (!this.isTauri()) {
       throw new Error("ping/ping6 仅在 桌面版 中支持使用");

--- a/tauri/tauri_api.js
+++ b/tauri/tauri_api.js
@@ -33,10 +33,6 @@ window.win12Native = {
     await window.__TAURI__.core.invoke("write_settings", { json: JSON.stringify(settings) });
     return true;
   },
-  async openExternalUrl(url) {
-    if (!this.isTauri()) return false;
-    return await window.__TAURI__.core.invoke("open_external_url", { url });
-  },
   async pingHost(host, ipv6 = false, onOutput = null) {
     if (!this.isTauri()) {
       throw new Error("ping/ping6 仅在 桌面版 中支持使用");


### PR DESCRIPTION
修复在desktop中点击外链无法跳转的问题 
修复方式:跳转到win12 edge浏览器

增强在desktop中的浏览器功能，调用系统浏览器访问网站实现可以访问不允许被嵌套的网站
以Github为演示
<img width="1923" height="1126" alt="image" src="https://github.com/user-attachments/assets/29a0250b-9696-4431-873f-ced2358267e7" />
