### PR TITLE
fix:修复"开始"右键菜单中“搜索”弹出的问题

### DIFF
--- a/desktop.js
+++ b/desktop.js
@@ -481,7 +481,7 @@ const cms = {
         ['<i class="bi bi-folder2-open"></i> ' + lang('文件资源管理器', 'explorer.name'), 'openapp(\'explorer\')'],
         ['<i class="bi bi-search"></i> 搜索', `$('#search-btn').addClass('show');hide_startmenu();
         $('#search-win').addClass('show-begin');setTimeout(() => {$('#search-win').addClass('show');
-        $('#search-input').focus();}, 0);`],
+        $('#search-input').focus();},200);`],
         '<hr>',
         ['<i class="bi bi-power"></i> 关机', 'window.location=\'shutdown.html\''],
         ['<i class="bi bi-arrow-counterclockwise"></i> 重启', 'window.location=\'reload.html\''],


### PR DESCRIPTION
通过修改SetTimeout时长修复下列内容：
若右键单击开始  > 搜索，搜索框弹出后立刻收回。