### PR TITLE
修复 README 中无法显示的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 </p>
 <details align="center">
   <summary>Star History</summary>
-  <a href="https://star-history.com/#win12-online/win12&Date" style="text-decoration:none">
-    <img src="https://api.star-history.com/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
+  <a href="https://star-history.dera.page/#win12-online/win12&Date" style="text-decoration:none">
+    <img src="https://star-history.dera.page/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
   </a>
 </details>
 

--- a/readme/README_en_us.md
+++ b/readme/README_en_us.md
@@ -29,8 +29,8 @@
 </p>
 <details align="center">
   <summary>Star History</summary>
-  <a href="https://star-history.com/#win12-online/win12&Date" style="text-decoration:none">
-<img src="https://api.star-history.com/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
+  <a href="https://star-history.dera.page/#win12-online/win12&Date" style="text-decoration:none">
+<img src="https://star-history.dera.page/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
   </a>
 </details>
 

--- a/readme/README_fr_fr.md
+++ b/readme/README_fr_fr.md
@@ -29,8 +29,8 @@
 </p>
 <details align="center">
   <summary>Historique des étoiles</summary>
-  <a href="https://star-history.com/#win12-online/win12&Date" style="text-decoration:none">
-<img src="https://api.star-history.com/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
+  <a href="https://star-history.dera.page/#win12-online/win12&Date" style="text-decoration:none">
+<img src="https://star-history.dera.page/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
   </a>
 </details>
 

--- a/readme/README_zh_tw.md
+++ b/readme/README_zh_tw.md
@@ -29,8 +29,8 @@
 </p>
 <details align="center">
   <summary>星史</summary>
-  <a href="https://star-history.com/#win12-online/win12&Date" style="text-decoration:none">
-<img src="https://api.star-history.com/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
+  <a href="https://star-history.dera.page/#win12-online/win12&Date" style="text-decoration:none">
+<img src="https://star-history.dera.page/svg?repos=win12-online/win12&type=Date" alt="Star History Chart">
   </a>
 </details>
 


### PR DESCRIPTION
当前的 Star History 图表因 GitHub stargazer API 限制已经失效，无法正常展示项目的星标趋势。本次修改将图表切换到新的数据源，使其重新可用。请合并此修复。